### PR TITLE
Fixes Android RTCVideoView.onLayout issue

### DIFF
--- a/RTCView.js
+++ b/RTCView.js
@@ -24,6 +24,7 @@ var v = requireNativeComponent('RTCVideoView', RTCView, {nativeOnly: {
   'importantForAccessibility': true,
   'rotation': true,
   'opacity': true,
+  'onLayout': true,
 }});
 
 module.exports = v;


### PR DESCRIPTION
Android was crashing in the simulator (OS versions 5.1 and 6.0) and device (version 5.1.1). This fixes the simulator issue. 