### PR TITLE
Make PeerConnection and MediaStream proper EventTargets

### DIFF
--- a/MediaStreamEvent.js
+++ b/MediaStreamEvent.js
@@ -2,7 +2,6 @@
 
 class MediaStreamEvent {
   type: string;
-  target;
   stream;
   constructor(type, eventInitDict) {
     this.type = type.toString();

--- a/RTCEvent.js
+++ b/RTCEvent.js
@@ -2,7 +2,6 @@
 
 class RTCEvent {
   type: string;
-  target;
   constructor(type, eventInitDict) {
     this.type = type.toString();
     Object.assign(this, eventInitDict);

--- a/RTCIceCandidateEvent.js
+++ b/RTCIceCandidateEvent.js
@@ -2,7 +2,6 @@
 
 class RTCIceCandidateEvent {
   type: string;
-  target;
   candidate;
   constructor(type, eventInitDict) {
     this.type = type.toString();

--- a/RTCMediaStream.js
+++ b/RTCMediaStream.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var EventTarget = require('event-target-shim');
 var React = require('react-native');
 var {
   DeviceEventEmitter,
@@ -7,9 +8,17 @@ var {
 } = React;
 var WebRTCModule = NativeModules.WebRTCModule;
 
-class RTCMediaStream {
+const MEDIA_STREAM_EVENTS = [
+  'active',
+  'inactive',
+  'addtrack',
+  'removetrack',
+];
+
+class RTCMediaStream extends EventTarget(MEDIA_STREAM_EVENTS) {
   _streamId: number;
   constructor(_streamId) {
+    super();
     this._streamId = _streamId;
     this.tracks = [];
   }

--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -116,23 +116,21 @@ class RTCPeerConnection extends RTCPeerConnectionBase {
         if (ev.id !== id) {
           return;
         }
-        this.onnegotiationneeded && this.onnegotiationneeded();
+        this.dispatchEvent(new RTCEvent('negotiationneeded'));
       }),
       DeviceEventEmitter.addListener('peerConnectionIceConnectionChanged', ev => {
         if (ev.id !== id) {
           return;
         }
         this.iceConnectionState = ev.iceConnectionState;
-        var event = new RTCEvent('iceconnectionstatechange', {target: this});
-        this.oniceconnectionstatechange && this.oniceconnectionstatechange(event);
+        this.dispatchEvent(new RTCEvent('iceconnectionstatechange'));
       }),
       DeviceEventEmitter.addListener('peerConnectionSignalingStateChanged', ev => {
         if (ev.id !== id) {
           return;
         }
         this.signalingState = ev.signalingState;
-        var event = new RTCEvent('signalingstatechange', {target: this});
-        this.onsignalingstatechange && this.onsignalingstatechange(event);
+        this.dispatchEvent(new RTCEvent('signalingstatechange'));
       }),
       DeviceEventEmitter.addListener('peerConnectionAddedStream', ev => {
         if (ev.id !== id) {
@@ -144,8 +142,7 @@ class RTCPeerConnection extends RTCPeerConnectionBase {
           stream.addTrack(new MediaStreamTrack(tracks[i]));
         }
         this._remoteStreams.push(stream);
-        var event = new MediaStreamEvent('addstream', {target: this, stream: stream});
-        this.onaddstream && this.onaddstream(event);
+        this.dispatchEvent(new MediaStreamEvent('addstream', {stream}));
       }),
       DeviceEventEmitter.addListener('peerConnectionRemovedStream', ev => {
         if (ev.id !== id) {
@@ -158,24 +155,22 @@ class RTCPeerConnection extends RTCPeerConnectionBase {
             this._remoteStreams.splice(index, 1);
           }
         }
-        var event = new MediaStreamEvent('removestream', {target: this, stream: stream});
-        this.onremovestream && this.onremovestream(event);
+        this.dispatchEvent(new MediaStreamEvent('removestream', {stream}));
       }),
       DeviceEventEmitter.addListener('peerConnectionGotICECandidate', ev => {
         if (ev.id !== id) {
           return;
         }
         var candidate = new RTCIceCandidate(ev.candidate);
-        var event = new RTCIceCandidateEvent('icecandidate', {target: this, candidate: candidate});
-        this.onicecandidate && this.onicecandidate(event);
+        var event = new RTCIceCandidateEvent('icecandidate', {candidate});
+        this.dispatchEvent(event);
       }),
       DeviceEventEmitter.addListener('peerConnectionIceGatheringChanged', ev => {
         if (ev.id !== id) {
           return;
         }
         this.iceGatheringState = ev.iceGatheringState;
-        var event = new RTCEvent('icegatheringstatechange', {target: this});
-        this.onicegatheringstatechange && this.onicegatheringstatechange(event);
+        this.dispatchEvent(new RTCEvent('icegatheringstatechange'));
       })
     ];
   }

--- a/RTCPeerConnectionBase.js
+++ b/RTCPeerConnectionBase.js
@@ -1,18 +1,38 @@
 'use strict';
 
+var EventTarget = require('event-target-shim');
 var RTCSessionDescription = require('./RTCSessionDescription');
 
-class RTCPeerConnectionBase {
+const PEER_CONNECTION_EVENTS = [
+  'connectionstatechange',
+  'icecandidate',
+  'icecandidateerror',
+  'iceconnectionstatechange',
+  'icegatheringstatechange',
+  'negotiationneeded',
+  'signalingstatechange',
+  // old:
+  'addstream',
+  'removestream',
+];
+
+class RTCPeerConnectionBase extends EventTarget(PEER_CONNECTION_EVENTS) {
   localDescription: RTCSessionDescription;
   remoteDescription: RTCSessionDescription;
 
+  onconnectionstatechange: ?Function;
   onicecandidate: ?Function;
-  onnegotiationneeded: ?Function;
+  onicecandidateerror: ?Function;
   oniceconnectionstatechange: ?Function;
+  onicegatheringstatechange: ?Function;
+  onnegotiationneeded: ?Function;
   onsignalingstatechange: ?Function;
+
   onaddstream: ?Function;
+  onremovestream: ?Function;
 
   constructor(configuration) {
+    super();
     this.constructorImpl(configuration);
   }
   addStream(stream) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "android",
     "webrtc"
   ],
+  "dependencies": {
+    "event-target-shim": "^1.0.5"
+  },
   "peerDependencies": {
     "react-native": ">=0.19.0"
   },


### PR DESCRIPTION
Implements the `EventTarget` spec for PeerConnection and MediaStream, so that code that uses `addEventListener`/`removeEventListener` will work out of the box. With this, `peerConnection.onfoobar = handler` and `peerConnection.addEventListener('foobar', handler)` are equivalent, just like in the browser (and the spec).