### PR TITLE
Complete MediaStreamTrack with Spec

### DIFF
--- a/MediaStream.js
+++ b/MediaStream.js
@@ -40,6 +40,7 @@ class MediaStream extends EventTarget(MEDIA_STREAM_EVENTS) {
     if (index === -1) {
       return;
     }
+    WebRTCModule.mediaStreamTrackRelease(this.id, track.id);
     this._tracks.splice(index, 1);
     this.dispatchEvent(new MediaStreamTrackEvent('removetrack', {track}));
   }

--- a/MediaStreamError.js
+++ b/MediaStreamError.js
@@ -1,0 +1,16 @@
+'use strict';
+
+class MediaStreamError {
+
+  name: string;
+  message: ?string;
+  constraintName: ?string;
+
+  constructor(error) {
+    this.name = error.name;
+    this.message = error.message;
+    this.constraintName = error.constraintName;
+  }
+}
+
+module.exports = MediaStreamError;

--- a/MediaStreamErrorEvent.js
+++ b/MediaStreamErrorEvent.js
@@ -1,0 +1,14 @@
+'use strict';
+
+import type MediaStreamError from './MediaStreamError';
+
+class MediaStreamErrorEvent {
+  type: string;
+  error: ?MediaStreamError;
+  constructor(type, eventInitDict) {
+    this.type = type.toString();
+    Object.assign(this, eventInitDict);
+  }
+}
+
+module.exports = MediaStreamErrorEvent;

--- a/MediaStreamTrack.js
+++ b/MediaStreamTrack.js
@@ -1,11 +1,20 @@
 'use strict';
 
-var React = require('react-native');
-var {
-  NativeModules,
-} = React;
+const EventTarget = require('event-target-shim');
+const WebRTCModule = require('react-native').NativeModules.WebRTCModule;
 
-var WebRTCModule = NativeModules.WebRTCModule;
+const MediaStreamErrorEvent = require('./MediaStreamErrorEvent');
+
+import type MediaStreamError from './MediaStreamError';
+
+const MEDIA_STREAM_TRACK_EVENTS = [
+  'ended',
+  'mute',
+  'unmute',
+  'overconstrained', // --- see: https://www.w3.org/TR/mediacapture-streams/#constrainable-interface
+];
+
+type MediaStreamTrackState = "live" | "ended";
 
 type SourceInfo = {
   id: string;
@@ -19,17 +28,77 @@ class MediaStreamTrack {
     WebRTCModule.mediaStreamTrackGetSources(success);
   }
 
-  enabled: boolean;
+  _enabled: boolean;
   id: number; // NOTE: spec wants string here
   kind: string;
   label: string;
   muted: boolean;
+  readonly: boolean; // how to decide?
+  readyState: MediaStreamTrackState; // readyState in java: INITIALIZING, LIVE, ENDED, FAILED
+  remote: boolean;
+
+  onended: ?Function;
+  onmute: ?Function;
+  onunmute: ?Function;
+  overconstrained: ?Function;
+
   constructor(info) {
+    this._enabled = info.enabled;
     this.id = info.id;
-    this.enabled = true;
     this.kind = info.kind;
     this.label = info.label;
     this.muted = false;
+    this.readonly = true; // how to decide?
+    this.remote = info.remote;
+    this.readyState = (info.readyState === "INITIALIZING"
+                    || info.readyState === "LIVE" ) ? "live" : "ended";
+  }
+
+  get enabled(): boolean {
+    return this._enabled;
+  }
+
+  set enabled(enabled: boolean): void {
+    if (enabled === this._enabled) {
+      return;
+    }
+    WebRTCModule.mediaStreamTrackSetEnabled(this.id, !this._enabled);
+    this._enabled = !this._enabled;
+    this.muted = !this._enabled;
+  }
+
+  stop() {
+    if (this.remote) {
+      return;
+    }
+    WebRTCModule.mediaStreamTrackStop(this.id);
+    this._enabled = false;
+    this.readyState = 'ended';
+    this.muted = !this._enabled;
+  }
+
+  applyConstraints() {
+    throw new Error('Not implemented.');
+  }
+
+  clone() {
+    throw new Error('Not implemented.');
+  }
+
+  getCapabilities() {
+    throw new Error('Not implemented.');
+  }
+
+  getConstraints() {
+    throw new Error('Not implemented.');
+  }
+
+  getSettings() {
+    throw new Error('Not implemented.');
+  }
+
+  clone() {
+    throw new Error('Not implemented.');
   }
 }
 

--- a/MediaStreamTrack.js
+++ b/MediaStreamTrack.js
@@ -100,6 +100,11 @@ class MediaStreamTrack {
   clone() {
     throw new Error('Not implemented.');
   }
+
+  setEnabled(enabled) {
+    WebRTCModule.trackSetEnabled(this.id, enabled);
+    this.enabled = enabled;
+  }
 }
 
 module.exports = MediaStreamTrack;

--- a/MediaStreamTrack.js
+++ b/MediaStreamTrack.js
@@ -43,6 +43,7 @@ class MediaStreamTrack {
   overconstrained: ?Function;
 
   constructor(info) {
+    let _readyState = info.readyState.toLowerCase();
     this._enabled = info.enabled;
     this.id = info.id;
     this.kind = info.kind;
@@ -50,8 +51,8 @@ class MediaStreamTrack {
     this.muted = false;
     this.readonly = true; // how to decide?
     this.remote = info.remote;
-    this.readyState = (info.readyState === "INITIALIZING"
-                    || info.readyState === "LIVE" ) ? "live" : "ended";
+    this.readyState = (_readyState === "initializing"
+                    || _readyState === "live") ? "live" : "ended";
   }
 
   get enabled(): boolean {
@@ -99,11 +100,6 @@ class MediaStreamTrack {
 
   clone() {
     throw new Error('Not implemented.');
-  }
-
-  setEnabled(enabled) {
-    WebRTCModule.trackSetEnabled(this.id, enabled);
-    this.enabled = enabled;
   }
 }
 

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -410,8 +410,8 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         track.setEnabled(false);
         track.setState(MediaStreamTrack.State.ENDED);
         mMediaStreamTracks.remove(trackId);
-		// what exaclty `detached` means in doc?
-		// see: https://www.w3.org/TR/mediacapture-streams/#track-detached
+        // what exaclty `detached` means in doc?
+        // see: https://www.w3.org/TR/mediacapture-streams/#track-detached
     }
 
     @ReactMethod
@@ -424,6 +424,26 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             return;
         }
         track.setEnabled(enabled);
+    }
+
+    @ReactMethod
+    public void mediaStreamTrackRelease(final int streamId, final String _trackId) {
+        // TODO: need to normalize streamId as a string ( spec wanted )
+        //final int streamId = Integer.parseInt(_streamId);
+        final int trackId = Integer.parseInt(_trackId);
+        MediaStream stream = mMediaStreams.get(streamId);
+        MediaStreamTrack track = mMediaStreamTracks.get(trackId);
+        if (track == null || stream == null) {
+            return;
+        }
+        track.setEnabled(false); // should we do this?
+        track.setState(MediaStreamTrack.State.ENDED); // should we do this?
+        mMediaStreamTracks.remove(trackId);
+        if (track.kind().equals("audio")) {
+            stream.removeTrack((AudioTrack)track);
+        } else if (track.kind().equals("video")) {
+            stream.removeTrack((VideoTrack)track);
+        }
     }
 
     public WritableMap getCameraInfo(int index) {

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -211,6 +211,9 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                     trackInfo.putString("id", mediaStreamTrackId + "");
                     trackInfo.putString("label", "Video");
                     trackInfo.putString("kind", track.kind());
+                    trackInfo.putBoolean("enabled", track.enabled());
+                    trackInfo.putString("readyState", track.state().toString());
+                    trackInfo.putBoolean("remote", true);
                     tracks.pushMap(trackInfo);
                 }
                 for (int i = 0; i < mediaStream.audioTracks.size(); i++) {
@@ -221,6 +224,9 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                     trackInfo.putString("id", mediaStreamTrackId + "");
                     trackInfo.putString("label", "Audio");
                     trackInfo.putString("kind", track.kind());
+                    trackInfo.putBoolean("enabled", track.enabled());
+                    trackInfo.putString("readyState", track.state().toString());
+                    trackInfo.putBoolean("remote", true);
                     tracks.pushMap(trackInfo);
                 }
                 params.putArray("tracks", tracks);
@@ -330,6 +336,9 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 trackInfo.putString("id", mediaStreamTrackId + "");
                 trackInfo.putString("label", "Video");
                 trackInfo.putString("kind", videoTrack.kind());
+                trackInfo.putBoolean("enabled", videoTrack.enabled());
+                trackInfo.putString("readyState", videoTrack.state().toString());
+                trackInfo.putBoolean("remote", false);
                 tracks.pushMap(trackInfo);
 
                 mediaStream.addTrack(videoTrack);
@@ -355,6 +364,9 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             trackInfo.putString("id", mediaStreamTrackId + "");
             trackInfo.putString("label", "Audio");
             trackInfo.putString("kind", audioTrack.kind());
+            trackInfo.putBoolean("enabled", audioTrack.enabled());
+            trackInfo.putString("readyState", audioTrack.state().toString());
+            trackInfo.putBoolean("remote", false);
             tracks.pushMap(trackInfo);
 
             mediaStream.addTrack(audioTrack);
@@ -386,6 +398,32 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
         array.pushMap(audio);
         callback.invoke(array);
+    }
+
+    @ReactMethod
+    public void mediaStreamTrackStop(final String id) {
+        final int trackId = Integer.parseInt(id);
+        MediaStreamTrack track = mMediaStreamTracks.get(trackId);
+        if (track == null) {
+            return;
+        }
+        track.setEnabled(false);
+        track.setState(MediaStreamTrack.State.ENDED);
+        mMediaStreamTracks.remove(trackId);
+		// what exaclty `detached` means in doc?
+		// see: https://www.w3.org/TR/mediacapture-streams/#track-detached
+    }
+
+    @ReactMethod
+    public void mediaStreamTrackSetEnabled(final String id, final boolean enabled) {
+        final int trackId = Integer.parseInt(id);
+        MediaStreamTrack track = mMediaStreamTracks.get(trackId);
+        if (track == null) {
+            return;
+        } else if (track.enabled() == enabled) {
+            return;
+        }
+        track.setEnabled(enabled);
     }
 
     public WritableMap getCameraInfo(int index) {

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -166,19 +166,21 @@ RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled:(nonnull NSNumber *)trackID : (BOOL
 
 RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSNumber *)streamID : (nonnull NSNumber *)trackID)
 {
-    if (self.mediaStreams[streamID]) {
-        RTCMediaStream *mediaStream = self.mediaStreams[streamID];
-        if (self.tracks[trackID]) {
-            RTCMediaStreamTrack *track = self.tracks[trackID];
-            if ([track.kind isEqualToString:@"audio"]) {
-                RTCAudioTrack *audioTrack = self.tracks[trackID];
-                [mediaStream removeAudioTrack:audioTrack];
-            } else if([track.kind isEqualToString:@"video"]) {
-                RTCVideoTrack *videoTrack = self.tracks[trackID];
-                [mediaStream removeVideoTrack:videoTrack];
-            }
-        }
+  // what's different to mediaStreamTrackStop? only call mediaStream explicitly?
+  if (self.mediaStreams[streamID] && self.tracks[trackID]) {
+    RTCMediaStream *mediaStream = self.mediaStreams[streamID];
+    RTCMediaStreamTrack *track = self.tracks[trackID];
+    [track setEnabled:NO];
+    if ([track.kind isEqualToString:@"audio"]) {
+      RTCAudioTrack *audioTrack = self.tracks[trackID];
+      [self.tracks removeObjectForKey:audioTrack.reactTag];
+      [mediaStream removeAudioTrack:audioTrack];
+    } else if([track.kind isEqualToString:@"video"]) {
+      RTCVideoTrack *videoTrack = self.tracks[trackID];
+      [self.tracks removeObjectForKey:videoTrack.reactTag];
+      [mediaStream removeVideoTrack:videoTrack];
     }
+  }
 }
 
 RCT_EXPORT_METHOD(mediaStreamRelease:(nonnull NSNumber *)streamID)

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -144,7 +144,6 @@ RCT_EXPORT_METHOD(trackSetEnabled:(nonnull NSNumber *)trackID : (BOOL *)enabled)
 {
     RTCMediaStreamTrack *track = self.tracks[trackID];
     [track setEnabled:enabled];
-    BOOL newValue = [track isEnabled];
 }
 
 RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSNumber *)streamID : (nonnull NSNumber *)trackID)

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -140,6 +140,29 @@ RCT_EXPORT_METHOD(mediaStreamTrackGetSources:(RCTResponseSenderBlock)callback) {
   callback(@[sources]);
 }
 
+RCT_EXPORT_METHOD(trackSetEnabled:(nonnull NSNumber *)trackID : (BOOL *)enabled)
+{
+    RTCMediaStreamTrack *track = self.tracks[trackID];
+    [track setEnabled:enabled];
+    BOOL newValue = [track isEnabled];
+}
+
+RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSNumber *)streamID : (nonnull NSNumber *)trackID)
+{
+    if (self.mediaStreams[streamID]) {
+        RTCMediaStream *mediaStream = self.mediaStreams[streamID];
+        if (self.tracks[trackID]) {
+            RTCMediaStreamTrack *track = self.tracks[trackID];
+            if ([track.kind isEqualToString:@"audio"]) {
+                RTCAudioTrack *audioTrack = self.tracks[trackID];
+                [mediaStream removeAudioTrack:audioTrack];
+            } else if([track.kind isEqualToString:@"video"]) {
+                RTCVideoTrack *videoTrack = self.tracks[trackID];
+                [mediaStream removeVideoTrack:videoTrack];
+            }
+        }
+    }
+}
 
 RCT_EXPORT_METHOD(mediaStreamRelease:(nonnull NSNumber *)streamID)
 {

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints callback:(RCTResponse
     NSNumber *trackId = @(self.trackId++);
     audioTrack.reactTag = trackId;
     self.tracks[trackId] = audioTrack;
-    [tracks addObject:@{@"id": trackId, @"kind": audioTrack.kind, @"label": audioTrack.label}];
+    [tracks addObject:@{@"id": trackId, @"kind": audioTrack.kind, @"label": audioTrack.label, @"enabled": @(audioTrack.isEnabled), @"remote": @(NO), @"readyState": @"live"}];
   }
 
   if (constraints[@"video"]) {
@@ -108,7 +108,8 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints callback:(RCTResponse
       NSNumber *trackId = @(self.trackId++);
       videoTrack.reactTag = trackId;
       self.tracks[trackId] = videoTrack;
-      [tracks addObject:@{@"id": trackId, @"kind": videoTrack.kind, @"label": videoTrack.label}];
+      [tracks addObject:@{@"id": trackId, @"kind": videoTrack.kind, @"label": videoTrack.label, @"enabled": @(videoTrack.isEnabled), @"remote": @(NO), @"readyState": @"live"}];
+
     }
   }
 
@@ -140,10 +141,27 @@ RCT_EXPORT_METHOD(mediaStreamTrackGetSources:(RCTResponseSenderBlock)callback) {
   callback(@[sources]);
 }
 
-RCT_EXPORT_METHOD(trackSetEnabled:(nonnull NSNumber *)trackID : (BOOL *)enabled)
+RCT_EXPORT_METHOD(mediaStreamTrackStop:(nonnull NSNumber *)trackID)
 {
-    RTCMediaStreamTrack *track = self.tracks[trackID];
+  RTCMediaStreamTrack *track = self.tracks[trackID];
+  if (track) {
+    [track setEnabled:NO];
+    if ([track.kind isEqualToString:@"audio"]) {
+      RTCAudioTrack *audioTrack = self.tracks[trackID];
+      [self.tracks removeObjectForKey:audioTrack.reactTag];
+    } else if([track.kind isEqualToString:@"video"]) {
+      RTCVideoTrack *videoTrack = self.tracks[trackID];
+      [self.tracks removeObjectForKey:videoTrack.reactTag];
+    }
+  }
+}
+
+RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled:(nonnull NSNumber *)trackID : (BOOL *)enabled)
+{
+  RTCMediaStreamTrack *track = self.tracks[trackID];
+  if (track && track.isEnabled != enabled) {
     [track setEnabled:enabled];
+  }
 }
 
 RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSNumber *)streamID : (nonnull NSNumber *)trackID)

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -281,13 +281,13 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSNumber *)trackID objectID:(n
     NSNumber *trackId = @(self.trackId++);
     track.reactTag = trackId;
     self.tracks[trackId] = track;
-    [tracks addObject:@{@"id": trackId, @"kind": track.kind, @"label": track.label}];
+    [tracks addObject:@{@"id": trackId, @"kind": track.kind, @"label": track.label, @"enabled": @(track.isEnabled), @"remote": @(YES), @"readyState": @"live"}];
   }
   for (RTCAudioTrack *track in stream.audioTracks) {
     NSNumber *trackId = @(self.trackId++);
     track.reactTag = trackId;
     self.tracks[trackId] = track;
-    [tracks addObject:@{@"id": trackId, @"kind": track.kind, @"label": track.label}];
+    [tracks addObject:@{@"id": trackId, @"kind": track.kind, @"label": track.label, @"enabled": @(track.isEnabled), @"remote": @(YES), @"readyState": @"live"}];
   }
 
   self.mediaStreams[objectID] = stream;


### PR DESCRIPTION
see comment in commit:

this PR:
close #51 
close #48
close #28 


### Complete MediaTrack member and method

1. pass correspond properties to js when create track.

2. implement track.enabled = true/false which can be used to mute a track.
3. MediaStream.removeTrack() will invoke native method now.
4. implement track.stop()
   maybe unnecessary to invoke it if we explicitly release media stream.
   but some implementation would use it when hangup.
   this also supported in chrome and firfox.

   I'm not exactly understand what this means, but here are some hints:
   [Google Developers - MediaStream Deprecations](https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en)
   [W3C track.stop() procedure](https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-stop)
   [W3C detached meaning](https://www.w3.org/TR/mediacapture-streams/#track-detached)

   what exaclty `detached` means in doc?


### NOTICE:

I'm confusing about what's the differences of behavior between `MediaStream.removeTrack()` and `MediaStreamTrack.stop()` ?

Currently my understanding is, `MediaStream.removeTrack()` will invoke native one `removeTrack`, thus the track will remove from stream. In the webrtc java source code, it iterate all tracks from mediaStream and `dispose()` ( aka `free()` ) each track.

`MediaStreamTrack.stop()` is just stop the track itself, will not be removed from mediaStream.

in short: both `track.stop()` and `mediaStream.removeTrack(track)` will STOP playing the track, and set `enable = false`;

if someone have a clear understanding, please fix those actions to consistent with the spec. thanks!

### Error Handling Object and Event

[js] add MediaStreamError Event type
this is just added the type object at the very first stage and nothing
todo with currently code base for now.

for future compatible with spec. maybe when we started to implement
[constrainable pattern interface](https://www.w3.org/TR/mediacapture-streams/#constrainable-interface)

and

[error
    handling](https://www.w3.org/TR/mediacapture-streams/#error-handling)