### PR TITLE
[android] fix switch syntax without break

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -129,6 +129,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                         } else {
                             iceServers.add(new PeerConnection.IceServer(iceServerMap.getString("urls")));
                         }
+                        break;
                     case Array:
                         ReadableArray urls = iceServerMap.getArray("urls");
                         for (int j = 0; j < urls.size(); j++) {
@@ -139,7 +140,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                                 iceServers.add(new PeerConnection.IceServer(url));
                             }
                         }
-
+                        break;
                 }
             }
         }
@@ -298,6 +299,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                             }
                         }
                     }
+                    break;
             }
             // videoConstraints.mandatory.add(new MediaConstraints.KeyValuePair("maxHeight", Integer.toString(100)));
             // videoConstraints.mandatory.add(new MediaConstraints.KeyValuePair("maxWidth", Integer.toString(100)));


### PR DESCRIPTION
when determine `urls` key type in createIceServers(),
swich without `break` would leads to fall-through all cases.
thus crash the app due to unmatched type String and Array.