### PR TITLE
Missing semicolon added

### DIFF
--- a/RTCDataChannel.js
+++ b/RTCDataChannel.js
@@ -55,7 +55,7 @@ class RTCDataChannel extends EventTarget(DATA_CHANNEL_EVENTS) {
   readyState: RTCDataChannelState = 'connecting';
 
   onopen: ?Function;
-  onmessage: ?Function
+  onmessage: ?Function;
   onbufferedamountlow: ?Function;
   onerror: ?Function;
   onclose: ?Function;


### PR DESCRIPTION
A semicolon is required after a class property.