### PR TITLE
Initialize RTCMediaStream with UUID

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -64,7 +64,13 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints callback:(RCTResponse
   
   NSMutableArray *tracks = [NSMutableArray array];
 
-  RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithLabel:@"ARDAMS"];
+  // Initialize RTCMediaStream with a unique label in order to allow multiple
+  // RTCMediaStream instances initialized by multiple getUserMedia calls to be
+  // added to 1 RTCPeerConnection instance. As suggested by
+  // https://www.w3.org/TR/mediacapture-streams/#mediastream to be a good
+  // practice, use a UUID (conforming to RFC4122).
+  NSString *mediaStreamUUID = [[NSUUID UUID] UUIDString];
+  RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithLabel:mediaStreamUUID];
 
   if (constraints[@"audio"] && [constraints[@"audio"] boolValue]) {
     RTCAudioTrack *audioTrack = [self.peerConnectionFactory audioTrackWithID:@"ARDAMSa0"];


### PR DESCRIPTION
The native counterpart of the implementation of getUserMedia in
WebRTCModule+RTCMediaStream.m initializes RTCMediaStream with 1 constant
label. That's a problem when RTCMediaStream instances gathered from
multiple getUserMedia (e.g. 1 getUserMedia for audio and 1 getUserMedia
for video)  calls are to be added to 1 RTCPeerConnection. The method
webrtc::PeerConnection::AddStream will not add (and return false for) a
MediaStreamIterface (i.e. RTCMediaStream) with a label equal to the
label of a previously added MediaStreamInterface (the function
CanAddLocalMediaStream implements the check.) Eventually, what the app
using react-native-webrtc will see is that only the first local
MediaStream is streamed to its remote peer.

The standard at https://www.w3.org/TR/mediacapture-streams/#mediastream
states that a good practice is to use a UUID conforming to RFC 4122.
This commit uses such a UUID in the implementation of getUserMedia and,
consequently, allows RTCMediaStreams from different getUserMedia calls
to be streamed through 1 RTCPeerConnection.