### PR TITLE
Remove a duplicate method definition

### DIFF
--- a/MediaStreamTrack.js
+++ b/MediaStreamTrack.js
@@ -97,10 +97,6 @@ class MediaStreamTrack {
   getSettings() {
     throw new Error('Not implemented.');
   }
-
-  clone() {
-    throw new Error('Not implemented.');
-  }
 }
 
 module.exports = MediaStreamTrack;


### PR DESCRIPTION
MediaStreamTrack.js contained two identical definitions of clone.