### PR TITLE
Remove an unnecessary check

### DIFF
--- a/RTCDataChannel.js
+++ b/RTCDataChannel.js
@@ -127,8 +127,7 @@ class RTCDataChannel extends EventTarget(DATA_CHANNEL_EVENTS) {
         this.readyState = ev.state;
         if (this.readyState === 'open') {
           this.dispatchEvent(new RTCDataChannelEvent('open', {channel: this}));
-        }
-        if (this.readyState === 'close') {
+        } else if (this.readyState === 'close') {
           this.dispatchEvent(new RTCDataChannelEvent('close', {channel: this}));
           this._unregisterEvents();
         }


### PR DESCRIPTION
RTCDataChannel's readyState cannot be === 'open' and 'close' at the same time so (1) it's more efficient (when this.readyState === 'open') and (2) it better expresses reality to use an if-else-if instead of a series of ifs.