### PR TITLE
Remove an unnecessary Array of local MediaStream

### DIFF
--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -74,7 +74,6 @@ class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENTS) {
   onremovestream: ?Function;
 
   _peerConnectionId: number;
-  _localStreams: Array<MediaStream> = [];
   _remoteStreams: Array<MediaStream> = [];
   _subscriptions: Array<any>;
 
@@ -87,14 +86,9 @@ class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENTS) {
 
   addStream(stream: MediaStream) {
     WebRTCModule.peerConnectionAddStream(stream.id, this._peerConnectionId);
-    this._localStreams.push(stream);
   }
 
   removeStream(stream: MediaStream) {
-    var index = this._localStreams.indexOf(stream);
-    if (index > -1) {
-      this._localStreams.splice(index, 1);
-    }
     WebRTCModule.peerConnectionRemoveStream(stream.id, this._peerConnectionId);
   }
 


### PR DESCRIPTION
RTCPeerConnection's _localStreams array seems to be superfluous because local MediaStream instances get added to and removed from it but there are no get (by MediaStream id) operations. Eventually, what _localStreams achieves is keeping a reference to a MediaStream and that's unnecessary.

It's also unlikely that _localStreams will be used with get operations in the future because the standard at https://www.w3.org/TR/webrtc/#rtcpeerconnection-interface doesn't define retrieving MediaStream instances through RTCPeerConnection.