### PR TITLE
[libjingle][ios] upgrade to revision 11177

### DIFF
--- a/ios/libjingle_peerconnection/Headers/RTCFileLogger.h
+++ b/ios/libjingle_peerconnection/Headers/RTCFileLogger.h
@@ -39,21 +39,38 @@ typedef NS_ENUM(NSUInteger, RTCFileLoggerSeverity) {
   kRTCFileLoggerSeverityError
 };
 
+typedef NS_ENUM(NSUInteger, RTCFileLoggerRotationType) {
+  kRTCFileLoggerTypeCall,
+  kRTCFileLoggerTypeApp,
+};
+
 // This class intercepts WebRTC logs and saves them to a file. The file size
 // will not exceed the given maximum bytesize. When the maximum bytesize is
-// reached logs from the beginning and the end are preserved while the middle
-// section is overwritten instead.
+// reached, logs are rotated according to the rotationType specified.
+// For kRTCFileLoggerTypeCall, logs from the beginning and the end
+// are preserved while the middle section is overwritten instead.
+// For kRTCFileLoggerTypeApp, the oldest log is overwritten.
 // This class is not threadsafe.
 @interface RTCFileLogger : NSObject
 
 // The severity level to capture. The default is kRTCFileLoggerSeverityInfo.
 @property(nonatomic, assign) RTCFileLoggerSeverity severity;
 
-// Default constructor provides default settings for dir path and file size.
+// The rotation type for this file logger. The default is
+// kRTCFileLoggerTypeCall.
+@property(nonatomic, readonly) RTCFileLoggerRotationType rotationType;
+
+// Default constructor provides default settings for dir path, file size and
+// rotation type.
 - (instancetype)init;
+
+// Create file logger with default rotation type.
+- (instancetype)initWithDirPath:(NSString *)dirPath
+                    maxFileSize:(NSUInteger)maxFileSize;
 
 - (instancetype)initWithDirPath:(NSString *)dirPath
                     maxFileSize:(NSUInteger)maxFileSize
+                   rotationType:(RTCFileLoggerRotationType)rotationType
     NS_DESIGNATED_INITIALIZER;
 
 // Starts writing WebRTC logs to disk if not already started. Overwrites any

--- a/ios/libjingle_peerconnection/Headers/RTCLogging.h
+++ b/ios/libjingle_peerconnection/Headers/RTCLogging.h
@@ -81,7 +81,7 @@ extern NSString* RTCFileName(const char* filePath);
 #define RTCLogError(format, ...)                                  \
   RTCLogFormat(kRTCLoggingSeverityError, format, ##__VA_ARGS__)   \
 
-#ifdef _DEBUG
+#if !defined(NDEBUG)
 #define RTCLogDebug(format, ...) RTCLogInfo(format, ##__VA_ARGS__)
 #else
 #define RTCLogDebug(format, ...) \

--- a/ios/libjingle_peerconnection/Headers/RTCPeerConnection.h
+++ b/ios/libjingle_peerconnection/Headers/RTCPeerConnection.h
@@ -27,6 +27,7 @@
 
 #import "RTCPeerConnectionDelegate.h"
 
+@class RTCConfiguration;
 @class RTCDataChannel;
 @class RTCDataChannelInit;
 @class RTCICECandidate;
@@ -97,10 +98,12 @@
     setRemoteDescriptionWithDelegate:(id<RTCSessionDescriptionDelegate>)delegate
                   sessionDescription:(RTCSessionDescription *)sdp;
 
-// Restarts or updates the ICE Agent process of gathering local candidates
-// and pinging remote candidates.
-- (BOOL)updateICEServers:(NSArray *)servers
-             constraints:(RTCMediaConstraints *)constraints;
+// Sets the PeerConnection's global configuration to |configuration|.
+// Any changes to STUN/TURN servers or ICE candidate policy will affect the
+// next gathering phase, and cause the next call to createOffer to generate
+// new ICE credentials. Note that the BUNDLE and RTCP-multiplexing policies
+// cannot be changed with this method.
+- (BOOL)setConfiguration:(RTCConfiguration *)configuration;
 
 // Provides a remote candidate to the ICE Agent.
 - (BOOL)addICECandidate:(RTCICECandidate *)candidate;

--- a/ios/libjingle_peerconnection/Headers/RTCPeerConnectionInterface.h
+++ b/ios/libjingle_peerconnection/Headers/RTCPeerConnectionInterface.h
@@ -63,11 +63,15 @@ typedef NS_ENUM(NSInteger, RTCTcpCandidatePolicy) {
 @property(nonatomic, assign) RTCRtcpMuxPolicy rtcpMuxPolicy;
 @property(nonatomic, assign) RTCTcpCandidatePolicy tcpCandidatePolicy;
 @property(nonatomic, assign) int audioJitterBufferMaxPackets;
+@property(nonatomic, assign) int iceConnectionReceivingTimeout;
+@property(nonatomic, assign) int iceBackupCandidatePairPingInterval;
 
 - (instancetype)initWithIceTransportsType:(RTCIceTransportsType)iceTransportsType
                              bundlePolicy:(RTCBundlePolicy)bundlePolicy
                             rtcpMuxPolicy:(RTCRtcpMuxPolicy)rtcpMuxPolicy
                        tcpCandidatePolicy:(RTCTcpCandidatePolicy)tcpCandidatePolicy
-              audioJitterBufferMaxPackets:(int)audioJitterBufferMaxPackets;
+              audioJitterBufferMaxPackets:(int)audioJitterBufferMaxPackets
+            iceConnectionReceivingTimeout:(int)iceConnectionReceivingTimeout
+       iceBackupCandidatePairPingInterval:(int)iceBackupCandidatePairPingInterval;
 
 @end

--- a/ios/libjingle_peerconnection/libjingle_peerconnection_revision_build.txt
+++ b/ios/libjingle_peerconnection/libjingle_peerconnection_revision_build.txt
@@ -1,0 +1,1 @@
+revision 11177 Release build


### PR DESCRIPTION
WebRTC lib is pre-build by [pristineio's webrtc-build-scripts](https://github.com/pristineio/webrtc-build-scripts)

This PR upgrade iOS lib to webrtc revision 11177. see: `ios/libjingle_peerconnection/libjingle_peerconnection_revision_build.txt`

**Why upgrade**

current webrtc version on iOS:

* I can run WebRTCDemo on iPhone6/iOS9 without problems.
* But I have silent voice on iPhone6/iOS9 if we relay to some TURN server. P2P is OK.
* It works on iPhone5/iOS9 for both TURN and P2P

I can't find the reason, but after I upgraded to 11177, the problems solved.
