### PR TITLE
Support remotely-opened RTCDataChannel

### DIFF
--- a/RTCDataChannel.js
+++ b/RTCDataChannel.js
@@ -29,10 +29,6 @@ type RTCDataChannelState =
   'closing' |
   'closed';
 
-const dataChannelIds = new Set();
-
-let nextDataChannelId = 0;
-
 const DATA_CHANNEL_EVENTS = [
   'open',
   'message',
@@ -63,33 +59,25 @@ class RTCDataChannel extends EventTarget(DATA_CHANNEL_EVENTS) {
   onerror: ?Function;
   onclose: ?Function;
 
-  constructor(peerConnectionId: number, label: string, options?: ?RTCDataChannelInit) {
+  constructor(label: string, dataChannelDict: RTCDataChannelInit) {
     super();
-
-    if (options && 'id' in options) {
-      if (typeof options.id !== 'number') {
-        throw new TypeError('DataChannel id must be a number: ' + options.id);
-      }
-      if (dataChannelIds.contains(options.id)) {
-        throw new ResourceInUse('DataChannel id already in use: ' + options.id);
-      }
-      this.id = options.id;
-    } else {
-      this.id = nextDataChannelId++;
-    }
-    dataChannelIds.add(this.id);
 
     this.label = label;
 
-    if (options) {
-      this.ordered = !!options.ordered;
-      this.maxPacketLifeTime = options.maxPacketLifeTime;
-      this.maxRetransmits = options.maxRetransmits;
-      this.protocol = options.protocol || '';
-      this.negotiated = !!options.negotiated;
-    }
+    // The standard defines dataChannelDict as optional for
+    // RTCPeerConnection#createDataChannel and that is how we have implemented
+    // the method in question. However, the method will (1) allocate an
+    // RTCDataChannel.id if the caller has not specified a value and (2)
+    // pass it to RTCDataChannel's constructor via dataChannelDict.
+    // Consequently, dataChannelDict is not optional for RTCDataChannel's
+    // constructor.
+    this.id = ('id' in dataChannelDict) ? dataChannelDict.id : -1;
+    this.ordered = !!dataChannelDict.ordered;
+    this.maxPacketLifeTime = dataChannelDict.maxPacketLifeTime;
+    this.maxRetransmits = dataChannelDict.maxRetransmits;
+    this.protocol = dataChannelDict.protocol || '';
+    this.negotiated = !!dataChannelDict.negotiated;
 
-    WebRTCModule.dataChannelInit(peerConnectionId, this.id, label, options);
     this._registerEvents();
   }
 

--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -11,6 +11,7 @@ import MediaStream from './MediaStream'
 import MediaStreamEvent from './MediaStreamEvent'
 import MediaStreamTrack from './MediaStreamTrack'
 import RTCDataChannel from './RTCDataChannel'
+import RTCDataChannelEvent from './RTCDataChannelEvent'
 import RTCSessionDescription from './RTCSessionDescription'
 import RTCIceCandidate from './RTCIceCandidate'
 import RTCIceCandidateEvent from './RTCIceCandidateEvent'
@@ -46,6 +47,8 @@ const PEER_CONNECTION_EVENTS = [
   'icegatheringstatechange',
   'negotiationneeded',
   'signalingstatechange',
+  // Peer-to-peer Data API:
+  'datachannel',
   // old:
   'addstream',
   'removestream',
@@ -75,6 +78,11 @@ class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENTS) {
   _peerConnectionId: number;
   _remoteStreams: Array<MediaStream> = [];
   _subscriptions: Array<any>;
+
+  /**
+   * The RTCDataChannel.id allocator of this RTCPeerConnection.
+   */
+  _dataChannelIds: Set = new Set();
 
   constructor(configuration) {
     super();
@@ -229,11 +237,74 @@ class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENTS) {
         }
         this.iceGatheringState = ev.iceGatheringState;
         this.dispatchEvent(new RTCEvent('icegatheringstatechange'));
+      }),
+      DeviceEventEmitter.addListener('peerConnectionDidOpenDataChannel', ev => {
+        if (ev.id !== this._peerConnectionId) {
+          return;
+        }
+        const evDataChannel = ev.dataChannel;
+        const id = evDataChannel.id;
+        // XXX RTP data channels are not defined by the WebRTC standard, have
+        // been deprecated in Chromium, and Google have decided (in 2015) to no
+        // longer support them (in the face of multiple reported issues of
+        // breakages).
+        if (typeof id !== 'number' || id === -1) {
+          return;
+        }
+        const channel = new RTCDataChannel(evDataChannel.label, evDataChannel);
+        // XXX webrtc::PeerConnection checked that id was not in use in its own
+        // SID allocator before it invoked us. Additionally, its own SID
+        // allocator is the authority on ResourceInUse. Consequently, it is
+        // (pretty) safe to update our RTCDataChannel.id allocator without
+        // checking for ResourceInUse.
+        this._dataChannelIds.add(id);
+        this.dispatchEvent(new RTCDataChannelEvent('datachannel', {channel}));
       })
     ];
   }
-  createDataChannel(label, options) {
-    return new RTCDataChannel(this._peerConnectionId, label, options);
+
+  /**
+   * Creates a new RTCDataChannel object with the given label. The
+   * RTCDataChannelInit dictionary can be used to configure properties of the
+   * underlying channel such as data reliability.
+   *
+   * @param {string} label - the value with which the label attribute of the new
+   * instance is to be initialized
+   * @param {RTCDataChannelInit} dataChannelDict - an optional dictionary of
+   * values with which to initialize corresponding attributes of the new
+   * instance such as id
+   */
+  createDataChannel(label: string, dataChannelDict?: ?RTCDataChannelInit) {
+    let id;
+    const dataChannelIds = this._dataChannelIds;
+    if (dataChannelDict && 'id' in dataChannelDict) {
+      id = dataChannelDict.id;
+      if (typeof id !== 'number') {
+        throw new TypeError('DataChannel id must be a number: ' + id);
+      }
+      if (dataChannelIds.contains(id)) {
+        throw new ResourceInUse('DataChannel id already in use: ' + id);
+      }
+    } else {
+      // Allocate a new id.
+      // TODO Remembering the last used/allocated id and then incrementing it to
+      // generate the next id to use will surely be faster. However, I want to
+      // reuse ids (in the future) as the RTCDataChannel.id space is limited to
+      // unsigned short by the standard:
+      // https://www.w3.org/TR/webrtc/#dom-datachannel-id. Additionally, 65535
+      // is reserved due to SCTP INIT and INIT-ACK chunks only allowing a
+      // maximum of 65535 streams to be negotiated (as defined by the WebRTC
+      // Data Channel Establishment Protocol).
+      for (id = 0; id < 65535 && dataChannelIds.contains(id); ++id);
+      // TODO Throw an error if no unused id is available.
+      dataChannelDict = Object.assign({id}, dataChannelDict);
+    }
+    WebRTCModule.createDataChannel(
+        this._peerConnectionId,
+        label,
+        dataChannelDict);
+    dataChannelIds.add(id);
+    return new RTCDataChannel(label, dataChannelDict);
   }
 }
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.h
+++ b/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.h
@@ -1,12 +1,6 @@
 #import "WebRTCModule.h"
 #import "RTCDataChannel.h"
 
-@interface RTCDataChannel (React)
-
-@property (nonatomic, strong) NSNumber *reactTag;
-
-@end
-
 @interface WebRTCModule (RTCDataChannel) <RTCDataChannelDelegate>
 
 @end


### PR DESCRIPTION
RTCDataChannel may be opened:

- either locally (which is already supported in react-native-webrtc)
using the Peer-to-peer Data API which extends the RTCPeerConnection
interface with the method createDataChannel

- or remotely (i.e. by the other peer). The local peer receives a
datachannel event through RTCPeerConnection. That's defined by the same
Peer-to-peer Data API.

In order to add support for the second scenario, remove reactTag from
DataChannel and use the streamId property of the Objective-C
RTCDataChannel as the id of the JavaScript counterpart (as done by the
browser API).