### PR TITLE
specify OpenGL version in AndroidManifest.xml

### DIFF
--- a/Documentation/AndroidInstallation.md
+++ b/Documentation/AndroidInstallation.md
@@ -6,6 +6,7 @@
 <uses-permission android:name="android.permission.CAMERA" />
 <uses-feature android:name="android.hardware.camera" />
 <uses-feature android:name="android.hardware.camera.autofocus"/>
+<uses-feature android:glEsVersion="0x00020000" android:required="true" />
 
 <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 <uses-permission android:name="android.permission.RECORD_AUDIO" />


### PR DESCRIPTION
Running without this was causing no video to appear in RTCViews on my Android device.

May fix #18.
