### PR TITLE
Style fixes

### DIFF
--- a/MediaStream.js
+++ b/MediaStream.js
@@ -1,14 +1,12 @@
 'use strict';
 
-import {
-  NativeModules,
-} from 'react-native';
-const WebRTCModule = NativeModules.WebRTCModule;
-
+import {NativeModules} from 'react-native';
 import EventTarget from 'event-target-shim';
 import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 
 import type MediaStreamTrack from './MediaStreamTrack';
+
+const {WebRTCModule} = NativeModules;
 
 const MEDIA_STREAM_EVENTS = [
   'active',
@@ -17,7 +15,7 @@ const MEDIA_STREAM_EVENTS = [
   'removetrack',
 ];
 
-class MediaStream extends EventTarget(MEDIA_STREAM_EVENTS) {
+export default class MediaStream extends EventTarget(MEDIA_STREAM_EVENTS) {
   id: number; // NOTE: spec wants string here
   active: boolean = true;
 
@@ -76,5 +74,3 @@ class MediaStream extends EventTarget(MEDIA_STREAM_EVENTS) {
     WebRTCModule.mediaStreamRelease(this.id);
   }
 }
-
-module.exports = MediaStream;

--- a/MediaStreamError.js
+++ b/MediaStreamError.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class MediaStreamError {
+export default class MediaStreamError {
 
   name: string;
   message: ?string;
@@ -12,5 +12,3 @@ class MediaStreamError {
     this.constraintName = error.constraintName;
   }
 }
-
-module.exports = MediaStreamError;

--- a/MediaStreamErrorEvent.js
+++ b/MediaStreamErrorEvent.js
@@ -2,7 +2,7 @@
 
 import type MediaStreamError from './MediaStreamError';
 
-class MediaStreamErrorEvent {
+export default class MediaStreamErrorEvent {
   type: string;
   error: ?MediaStreamError;
   constructor(type, eventInitDict) {
@@ -10,5 +10,3 @@ class MediaStreamErrorEvent {
     Object.assign(this, eventInitDict);
   }
 }
-
-module.exports = MediaStreamErrorEvent;

--- a/MediaStreamEvent.js
+++ b/MediaStreamEvent.js
@@ -2,7 +2,7 @@
 
 import type MediaStream from './MediaStream';
 
-class MediaStreamEvent {
+export default class MediaStreamEvent {
   type: string;
   stream: MediaStream;
   constructor(type, eventInitDict) {
@@ -10,5 +10,3 @@ class MediaStreamEvent {
     Object.assign(this, eventInitDict);
   }
 }
-
-module.exports = MediaStreamEvent;

--- a/MediaStreamTrack.js
+++ b/MediaStreamTrack.js
@@ -1,20 +1,19 @@
 'use strict';
 
-import {
-  NativeModules,
-} from 'react-native';
-const WebRTCModule = NativeModules.WebRTCModule;
-
+import {NativeModules} from 'react-native';
 import EventTarget from 'event-target-shim';
 import MediaStreamErrorEvent from './MediaStreamErrorEvent';
 
 import type MediaStreamError from './MediaStreamError';
 
+const {WebRTCModule} = NativeModules;
+
 const MEDIA_STREAM_TRACK_EVENTS = [
   'ended',
   'mute',
   'unmute',
-  'overconstrained', // --- see: https://www.w3.org/TR/mediacapture-streams/#constrainable-interface
+  // see: https://www.w3.org/TR/mediacapture-streams/#constrainable-interface
+  'overconstrained',
 ];
 
 type MediaStreamTrackState = "live" | "ended";
@@ -26,7 +25,7 @@ type SourceInfo = {
   kind: string;
 };
 
-class MediaStreamTrack {
+export default class MediaStreamTrack {
   static getSources(success: (sources: Array<SourceInfo>) => void) {
     WebRTCModule.mediaStreamTrackGetSources(success);
   }
@@ -37,7 +36,8 @@ class MediaStreamTrack {
   label: string;
   muted: boolean;
   readonly: boolean; // how to decide?
-  readyState: MediaStreamTrackState; // readyState in java: INITIALIZING, LIVE, ENDED, FAILED
+  // readyState in java: INITIALIZING, LIVE, ENDED, FAILED
+  readyState: MediaStreamTrackState;
   remote: boolean;
 
   onended: ?Function;
@@ -101,5 +101,3 @@ class MediaStreamTrack {
     throw new Error('Not implemented.');
   }
 }
-
-module.exports = MediaStreamTrack;

--- a/MediaStreamTrackEvent.js
+++ b/MediaStreamTrackEvent.js
@@ -2,7 +2,7 @@
 
 import type MediaStreamTrack from './MediaStreamTrack';
 
-class MediaStreamTrackEvent {
+export default class MediaStreamTrackEvent {
   type: string;
   track: MediaStreamTrack;
   constructor(type, eventInitDict) {
@@ -10,5 +10,3 @@ class MediaStreamTrackEvent {
     Object.assign(this, eventInitDict);
   }
 }
-
-module.exports = MediaStreamTrackEvent;

--- a/MessageEvent.js
+++ b/MessageEvent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class MessageEvent {
+export default class MessageEvent {
   type: string;
   data: string | ArrayBuffer | Blob;
   origin: string;
@@ -9,5 +9,3 @@ class MessageEvent {
     Object.assign(this, eventInitDict);
   }
 }
-
-module.exports = MessageEvent;

--- a/RTCDataChannel.js
+++ b/RTCDataChannel.js
@@ -1,16 +1,12 @@
 'use strict';
 
+import {NativeModules, DeviceEventEmitter} from 'react-native';
+import base64 from 'base64-js';
+import EventTarget from 'event-target-shim';
+import MessageEvent from './MessageEvent';
+import RTCDataChannelEvent from './RTCDataChannelEvent';
 
-import {
-  NativeModules,
-  DeviceEventEmitter,
-} from 'react-native';
-const WebRTCModule = NativeModules.WebRTCModule;
-
-import base64 from 'base64-js'
-import EventTarget from 'event-target-shim'
-import MessageEvent from './MessageEvent'
-import RTCDataChannelEvent from './RTCDataChannelEvent'
+const {WebRTCModule} = NativeModules;
 
 type RTCDataChannelInit = {
   ordered?: boolean;
@@ -39,7 +35,7 @@ const DATA_CHANNEL_EVENTS = [
 
 class ResourceInUse extends Error {}
 
-class RTCDataChannel extends EventTarget(DATA_CHANNEL_EVENTS) {
+export default class RTCDataChannel extends EventTarget(DATA_CHANNEL_EVENTS) {
 
   binaryType: 'arraybuffer' = 'arraybuffer'; // we only support 'arraybuffer'
   bufferedAmount: number = 0;
@@ -137,5 +133,3 @@ class RTCDataChannel extends EventTarget(DATA_CHANNEL_EVENTS) {
   }
 
 }
-
-module.exports = RTCDataChannel;

--- a/RTCDataChannelEvent.js
+++ b/RTCDataChannelEvent.js
@@ -2,7 +2,7 @@
 
 import type RTCDataChannel from './RTCDataChannel';
 
-class RTCDataChannelEvent {
+export default class RTCDataChannelEvent {
   type: string;
   channel: RTCDataChannel;
   constructor(type, eventInitDict) {
@@ -10,5 +10,3 @@ class RTCDataChannelEvent {
     Object.assign(this, eventInitDict);
   }
 }
-
-module.exports = RTCDataChannelEvent;

--- a/RTCEvent.js
+++ b/RTCEvent.js
@@ -1,11 +1,9 @@
 'use strict';
 
-class RTCEvent {
+export default class RTCEvent {
   type: string;
   constructor(type, eventInitDict) {
     this.type = type.toString();
     Object.assign(this, eventInitDict);
   }
 }
-
-module.exports = RTCEvent;

--- a/RTCIceCandidate.js
+++ b/RTCIceCandidate.js
@@ -1,17 +1,21 @@
 'use strict';
 
-class RTCIceCandidate {
+export default class RTCIceCandidate {
   candidate: string;
   sdpMLineIndex: number;
   sdpMid: string;
+
   constructor(info) {
     this.candidate = info.candidate;
     this.sdpMLineIndex = info.sdpMLineIndex;
     this.sdpMid = info.sdpMid;
   }
+
   toJSON() {
-    return {candidate: this.candidate, sdpMLineIndex: this.sdpMLineIndex, sdpMid: this.sdpMid};
+    return {
+      candidate: this.candidate,
+      sdpMLineIndex: this.sdpMLineIndex,
+      sdpMid: this.sdpMid,
+    };
   }
 }
-
-module.exports = RTCIceCandidate;

--- a/RTCIceCandidateEvent.js
+++ b/RTCIceCandidateEvent.js
@@ -1,12 +1,12 @@
 'use strict';
 
-class RTCIceCandidateEvent {
+import type RTCIceCandidate from './RTCIceCandidate';
+
+export default class RTCIceCandidateEvent {
   type: string;
-  candidate;
+  candidate: RTCIceCandidate;
   constructor(type, eventInitDict) {
     this.type = type.toString();
     Object.assign(this, eventInitDict);
   }
 }
-
-module.exports = RTCIceCandidateEvent;

--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -1,21 +1,19 @@
 'use strict';
 
-import EventTarget from 'event-target-shim'
-import {
-  DeviceEventEmitter,
-  NativeModules,
-} from 'react-native';
-const WebRTCModule = NativeModules.WebRTCModule;
+import EventTarget from 'event-target-shim';
+import {DeviceEventEmitter, NativeModules} from 'react-native';
 
-import MediaStream from './MediaStream'
-import MediaStreamEvent from './MediaStreamEvent'
-import MediaStreamTrack from './MediaStreamTrack'
-import RTCDataChannel from './RTCDataChannel'
-import RTCDataChannelEvent from './RTCDataChannelEvent'
-import RTCSessionDescription from './RTCSessionDescription'
-import RTCIceCandidate from './RTCIceCandidate'
-import RTCIceCandidateEvent from './RTCIceCandidateEvent'
-import RTCEvent from './RTCEvent'
+import MediaStream from './MediaStream';
+import MediaStreamEvent from './MediaStreamEvent';
+import MediaStreamTrack from './MediaStreamTrack';
+import RTCDataChannel from './RTCDataChannel';
+import RTCDataChannelEvent from './RTCDataChannelEvent';
+import RTCSessionDescription from './RTCSessionDescription';
+import RTCIceCandidate from './RTCIceCandidate';
+import RTCIceCandidateEvent from './RTCIceCandidateEvent';
+import RTCEvent from './RTCEvent';
+
+const {WebRTCModule} = NativeModules;
 
 type RTCSignalingState =
   'stable' |
@@ -56,7 +54,7 @@ const PEER_CONNECTION_EVENTS = [
 
 let nextPeerConnectionId = 0;
 
-class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENTS) {
+export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENTS) {
   localDescription: RTCSessionDescription;
   remoteDescription: RTCSessionDescription;
 
@@ -307,5 +305,3 @@ class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENTS) {
     return new RTCDataChannel(label, dataChannelDict);
   }
 }
-
-module.exports = RTCPeerConnection;

--- a/RTCSessionDescription.js
+++ b/RTCSessionDescription.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class RTCSessionDescription {
+export default class RTCSessionDescription {
   sdp: string;
   type: string;
 
@@ -12,4 +12,3 @@ class RTCSessionDescription {
     return {sdp: this.sdp, type: this.type};
   }
 }
-module.exports = RTCSessionDescription;

--- a/RTCView.js
+++ b/RTCView.js
@@ -5,11 +5,9 @@ import {
   NativeModules,
   requireNativeComponent,
 } from 'react-native';
-const WebRTCModule = NativeModules.WebRTCModule;
+import {PropTypes} from 'react';
 
-import {
-  PropTypes,
-} from 'react';
+const {WebRTCModule} = NativeModules;
 
 const RTCView = {
   name: 'RTCVideoView',
@@ -18,7 +16,7 @@ const RTCView = {
   },
 };
 
-const v = requireNativeComponent('RTCVideoView', RTCView, {nativeOnly: {
+const View = requireNativeComponent('RTCVideoView', RTCView, {nativeOnly: {
   testID: true,
   accessibilityComponentType: true,
   renderToHardwareTextureAndroid: true,
@@ -28,4 +26,4 @@ const v = requireNativeComponent('RTCVideoView', RTCView, {nativeOnly: {
   onLayout: true,
 }});
 
-module.exports = v;
+export default View;

--- a/getUserMedia.js
+++ b/getUserMedia.js
@@ -1,14 +1,13 @@
 'use strict';
 
-import {
-  NativeModules,
-} from 'react-native';
-const WebRTCModule = NativeModules.WebRTCModule;
+import {NativeModules} from 'react-native';
 
 import MediaStream from './MediaStream';
 import MediaStreamTrack from './MediaStreamTrack';
 
-function getUserMedia(constraints, success, failure) {
+const {WebRTCModule} = NativeModules;
+
+export default function getUserMedia(constraints, success, failure) {
   WebRTCModule.getUserMedia(constraints, (id, tracks) => {
     const stream = new MediaStream(id);
     for (let i = 0; i < tracks.length; i++) {
@@ -18,5 +17,3 @@ function getUserMedia(constraints, success, failure) {
     success(stream);
   });
 }
-
-module.exports = getUserMedia;

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-import RTCPeerConnection from './RTCPeerConnection'
-import RTCIceCandidate from './RTCIceCandidate'
-import RTCSessionDescription from './RTCSessionDescription'
-import RTCView from './RTCView'
-import MediaStream from './MediaStream'
-import MediaStreamTrack from './MediaStreamTrack'
-import getUserMedia from './getUserMedia'
+import RTCPeerConnection from './RTCPeerConnection';
+import RTCIceCandidate from './RTCIceCandidate';
+import RTCSessionDescription from './RTCSessionDescription';
+import RTCView from './RTCView';
+import MediaStream from './MediaStream';
+import MediaStreamTrack from './MediaStreamTrack';
+import getUserMedia from './getUserMedia';
 
 module.exports = {
   RTCPeerConnection,


### PR DESCRIPTION
- import statements need to be determinated by semicolons too
- if we're using ES6 imports now, we might as well use ES6 exports too
- strive to stay within 80 chars per line