### PR TITLE
AndroidManifest.xml update - Package name fix

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.oney.ReactNativeWebRTC">
+          package="com.oney.WebRTCModule">
 </manifest>


### PR DESCRIPTION
`react-native link` was failing to update the android project with the proper import class path.
This resolves the issue.