### PR TITLE
Implement PeerConnection.getRemoteStreams()

### DIFF
--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -161,6 +161,10 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
     }
   }
 
+  getRemoteStreams() {
+    return this._remoteStreams.slice();
+  }
+
   close() {
     WebRTCModule.peerConnectionClose(this._peerConnectionId);
   }


### PR DESCRIPTION
RCTWebRTCDemo is using it, but to my surprise it was missing. Easy enough to implement though :)