### PR TITLE
android: disable git-lfs and remove 64-bit .so in libjingle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-libjingle_peerconnection.so.jar filter=lfs diff=lfs merge=lfs -text
 libWebRTC.a filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION

see: https://github.com/jitsi/jitsi-meet-react/commit/30a9ca40750f6a01a5eae0f8fa5c428ce541b147

> The project react-native does not provide 64-bit binaries. The project
react-native-webrtc though does provide 64-bit binaries. Unfortunately,
the app will crash at runtime on 64-bit platforms if the .apk contains
any 64-bit binaries. The solution found at
https://corbt.com/posts/2015/09/18/mixing-32-and-64bit-dependencies-in-android.html
is to explicitly exclude each 64-bit binary from during packaging.


related issue:

#131 
#111