### PR TITLE
Ensure [RTCConvert RTCConfiguration:] always returns an RTCConfiguration

### DIFF
--- a/ios/RCTWebRTC/RCTConvert+WebRTC.m
+++ b/ios/RCTWebRTC/RCTConvert+WebRTC.m
@@ -85,19 +85,18 @@
   return [[RTCIceServer alloc] initWithURLStrings:urls];
 }
 
-+ (RTCConfiguration *)RTCConfiguration:(id)json
++ (nonnull RTCConfiguration *)RTCConfiguration:(id)json
 {
+  RTCConfiguration *config = [[RTCConfiguration alloc] init];
 
   if (!json) {
-    return nil;
+    return config;
   }
 
   if (![json isKindOfClass:[NSDictionary class]]) {
     RCTLogConvertError(json, @"must be an object");
-    return nil;
+    return config;
   }
-
-  RTCConfiguration *config = [[RTCConfiguration alloc] init];
 
   if (json[@"iceServers"] != nil && [json[@"iceServers"] isKindOfClass:[NSArray class]]) {
     NSMutableArray<RTCIceServer *> *iceServers = [NSMutableArray new];


### PR DESCRIPTION
It's perfectly fine to create an RTCPeerConnection without passing a configuration object (so long as you use setConfiguration() later), but native will return nil if you pass a nil configuration to the factory.