### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc",
-  "version": "0.54.4",
+  "version": "0.54.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/oney/react-native-webrtc.git"


### PR DESCRIPTION
as for change https://github.com/oney/react-native-webrtc/pull/190 we need to bump the version so people will get it via npm update.