### PR TITLE
Allow for null facingMode and null constraint maps in getUserMedia (Android)

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/ReactBridgeUtil.java
+++ b/android/src/main/java/com/oney/WebRTCModule/ReactBridgeUtil.java
@@ -15,6 +15,9 @@ public class ReactBridgeUtil {
      * <tt>null</tt> if there is no value mapped for given <tt>key</tt>.
      */
     public static String getMapStrValue(ReadableMap map, String key) {
+        if(!map.hasKey(key)){
+            return null;
+        }
         ReadableType type = map.getType(key);
         switch (type) {
             case Boolean:

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -218,7 +218,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     private MediaConstraints parseConstraints(ReadableMap constraintsMap) {
         MediaConstraints mediaConstraints = new MediaConstraints();
 
-        if (constraintsMap.getType("mandatory") == ReadableType.Map) {
+        if (constraintsMap.hasKey("mandatory") && constraintsMap.getType("mandatory") == ReadableType.Map) {
             ReadableMap mandatory = constraintsMap.getMap("mandatory");
             ReadableMapKeySetIterator keyIterator = mandatory.keySetIterator();
 
@@ -233,7 +233,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             Log.d(TAG, "mandatory constraints are not a map");
         }
 
-        if (constraintsMap.getType("optional") == ReadableType.Array) {
+        if (constraintsMap.hasKey("optional") && constraintsMap.getType("optional") == ReadableType.Array) {
             ReadableArray options = constraintsMap.getArray("optional");
 
             for (int i = 0; i < options.size(); i++) {


### PR DESCRIPTION
GUM constraints like the following example from the readme:
```
getUserMedia({
  audio: false,
  video: {
    optional: [{sourceId: selectedCamera.id}]
  }
}
```
Are crashing on Android when attempting to get non-existent `mandatory` key from map-type constraints and attempting to get non-existent `facingMode` key for video constraints.

This PR adds `hasKey()` checks to ensure the keys exist before getting the values.