### PR TITLE
android: remove unused API methods

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -12,7 +12,6 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableMap;
@@ -32,12 +31,8 @@ import java.util.UUID;
 import android.util.Base64;
 import android.util.SparseArray;
 import android.hardware.Camera;
-import android.media.AudioManager;
 import android.content.Context;
-import android.view.Window;
-import android.view.WindowManager;
 import android.app.Activity;
-import android.os.PowerManager;
 
 import android.opengl.EGLContext;
 import android.util.Log;
@@ -163,7 +158,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     public void peerConnectionInit(ReadableMap configuration, int id){
         PeerConnection.RTCConfiguration config = parseRTCConfiguration(configuration);
         PeerConnectionObserver observer = new PeerConnectionObserver(this, id);
-        PeerConnection peerConnection = mFactory.createPeerConnection(config, pcConstraints, observer); 
+        PeerConnection peerConnection = mFactory.createPeerConnection(config, pcConstraints, observer);
         observer.setPeerConnection(peerConnection);
         mPeerConnectionObservers.put(id, observer);
     }
@@ -876,9 +871,8 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             pco.close();
             mPeerConnectionObservers.remove(id);
         }
-
-        resetAudio();
     }
+
     @ReactMethod
     public void mediaStreamRelease(final String id) {
         MediaStream mediaStream = mMediaStreams.get(id);
@@ -895,42 +889,6 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         } else {
             Log.d(TAG, "mediaStreamRelease() mediaStream is null");
         }
-    }
-    private void resetAudio() {
-        AudioManager audioManager = (AudioManager)getReactApplicationContext().getSystemService(Context.AUDIO_SERVICE);
-        audioManager.setSpeakerphoneOn(true);
-        audioManager.setMode(AudioManager.MODE_NORMAL);
-    }
-    @ReactMethod
-    public void setAudioOutput(String output) {
-        AudioManager audioManager = (AudioManager)getReactApplicationContext().getSystemService(Context.AUDIO_SERVICE);
-        audioManager.setMode(AudioManager.MODE_IN_CALL);
-        audioManager.setSpeakerphoneOn(output.equals("speaker"));
-    }
-    @ReactMethod
-    public void setKeepScreenOn(final boolean isOn) {
-        UiThreadUtil.runOnUiThread(new Runnable() {
-            public void run() {
-                Window window = getCurrentActivity().getWindow();
-                if (isOn) {
-                    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                } else {
-                    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                }
-            }
-        });
-    }
-
-    @ReactMethod
-    public void setProximityScreenOff(boolean enabled) {
-        // TODO
-        /*
-        PowerManager powerManager = (PowerManager)getReactApplicationContext().getSystemService(Context.POWER_SERVICE);
-        if (powerManager.isWakeLockLevelSupported(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK)) {
-            PowerManager.WakeLock wakeLock = powerManager.newWakeLock(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK, TAG);
-            wakeLock.setReferenceCounted(false);
-        } else {
-        }*/
     }
 
     @ReactMethod


### PR DESCRIPTION
These are better handled by a module such as
react-native-incall-manager.

Only resetAudio() was used, which was arguably incorrect, since it's up to
the user to decide what audio mode they want for their application.