### PR TITLE
MediaStream, not RTCMediaStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ In your `index.ios.js`/`index.android.js`, you can require WebRTC to import RTCP
 var WebRTC = require('react-native-webrtc');
 var {
   RTCPeerConnection,
-  RTCMediaStream,
   RTCIceCandidate,
   RTCSessionDescription,
   RTCView,
+  MediaStream,
   MediaStreamTrack,
   getUserMedia,
 } = WebRTC;


### PR DESCRIPTION
RTCMediaStream doesn't exist, fixing a typo.