### PR TITLE
Add ability to switch cameras on the fly

### DIFF
--- a/MediaStreamTrack.js
+++ b/MediaStreamTrack.js
@@ -83,6 +83,23 @@ export default class MediaStreamTrack extends EventTarget(MEDIA_STREAM_TRACK_EVE
     this.muted = !this._enabled;
   }
 
+  /**
+   * Private / custom API for switching the cameras on the fly, without the
+   * need for adding / removing tracks or doing any SDP renegotiation.
+   *
+   * This is how the reference application (AppRTCMobile) implements camera
+   * switching.
+   */
+  _switchCamera() {
+    if (this.remote) {
+      throw new Error('Not implemented for remote tracks');
+    }
+    if (this.kind !== 'video') {
+      throw new Error('Only implemented for video tracks');
+    }
+    WebRTCModule.mediaStreamTrackSwitchCamera(this.id);
+  }
+
   applyConstraints() {
     throw new Error('Not implemented.');
   }

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ And set stream to RTCView
 ```javascript
 container.setState({videoURL: stream.toURL()});
 ```
+
+### Custom APIs
+
+#### MediaStreamTrack.prototype._switchCameras()
+
+This function allows to switch the front / back cameras in a video track
+on the fly, without the need for adding / removing tracks or renegotiating.
+
 ## Demos
 
 **Official Demo**

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -522,6 +522,19 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void mediaStreamTrackSwitchCamera(final String id) {
+        MediaStreamTrack track = mMediaStreamTracks.get(id);
+        if (track != null) {
+            VideoCapturer videoCapturer = mVideoCapturers.get(id);
+            if (videoCapturer != null) {
+                CameraVideoCapturer cameraVideoCapturer
+                    = (CameraVideoCapturer) videoCapturer;
+                cameraVideoCapturer.switchCamera(null);
+            }
+        }
+    }
+
+    @ReactMethod
     public void mediaStreamTrackRelease(final String streamId, final String _trackId) {
         MediaStream stream = mMediaStreams.get(streamId);
         if (stream == null) {

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -355,6 +355,19 @@ RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled:(nonnull NSString *)trackID : (BOOL
   }
 }
 
+RCT_EXPORT_METHOD(mediaStreamTrackSwitchCamera:(nonnull NSString *)trackID)
+{
+  RTCMediaStreamTrack *track = self.tracks[trackID];
+  if (track) {
+    RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
+    RTCVideoSource *source = videoTrack.source;
+    if ([source isKindOfClass:[RTCAVFoundationVideoSource class]]) {
+      RTCAVFoundationVideoSource *avSource = (RTCAVFoundationVideoSource *)source;
+      avSource.useBackCamera = !avSource.useBackCamera;
+    }
+  }
+}
+
 RCT_EXPORT_METHOD(mediaStreamTrackStop:(nonnull NSString *)trackID)
 {
   RTCMediaStreamTrack *track = self.tracks[trackID];


### PR DESCRIPTION
This patch adds a private custom API for switching the cameras on a
video track on the fly, without the need for add / removing tracks or
renegotiating.

It's MediaStreamTrack._switchCamera() and it only works for local video
streams, it will throw otherwise.

This is how the reference application AppRTCMobile implements camera
switching.