### PR TITLE
Promise support

### DIFF
--- a/MediaStreamTrack.js
+++ b/MediaStreamTrack.js
@@ -27,7 +27,11 @@ type SourceInfo = {
 
 export default class MediaStreamTrack extends EventTarget(MEDIA_STREAM_TRACK_EVENTS) {
   static getSources(success: (sources: Array<SourceInfo>) => void) {
-    WebRTCModule.mediaStreamTrackGetSources(success);
+    const promise = WebRTCModule.mediaStreamTrackGetSources();
+    if (success) {
+      return promise.then(success);
+    }
+    return promise;
   }
 
   _enabled: boolean;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ see [#190](https://github.com/oney/react-native-webrtc/pull/190) for detials
 ## WebRTC Revision
 
 Since `0.53`, we use same branch version number like in webrtc native.
-please see [wiki page](https://github.com/oney/react-native-webrtc/wiki) about revision history 
+please see [wiki page](https://github.com/oney/react-native-webrtc/wiki) about revision history
 
 ### format:
 
@@ -47,7 +47,7 @@ the order of commit revision is nothing to do with the order of cherry-picks, fo
 - [iOS](https://github.com/oney/react-native-webrtc/blob/master/Documentation/iOSInstallation.md)
 - [Android](https://github.com/oney/react-native-webrtc/blob/master/Documentation/AndroidInstallation.md)
 
-note: 0.10.0~0.12.0 required `git-lfs`, see: [git-lfs-installation](https://github.com/oney/react-native-webrtc/blob/master/Documentation/git-lfs-installation.md) 
+note: 0.10.0~0.12.0 required `git-lfs`, see: [git-lfs-installation](https://github.com/oney/react-native-webrtc/blob/master/Documentation/git-lfs-installation.md)
 
 ## Usage
 Now, you can use WebRTC like in browser.
@@ -71,37 +71,42 @@ var configuration = {"iceServers": [{"url": "stun:stun.l.google.com:19302"}]};
 var pc = new RTCPeerConnection(configuration);
 
 let isFront = true;
-MediaStreamTrack.getSources(sourceInfos => {
-  console.log(sourceInfos);
-  let videoSourceId;
-  for (const i = 0; i < sourceInfos.length; i++) {
-    const sourceInfo = sourceInfos[i];
-    if(sourceInfo.kind == "video" && sourceInfo.facing == (isFront ? "front" : "back")) {
-      videoSourceId = sourceInfo.id;
+MediaStreamTrack
+  .getSources()
+  .then(sourceInfos => {
+    console.log(sourceInfos);
+    let videoSourceId;
+    for (const i = 0; i < sourceInfos.length; i++) {
+      const sourceInfo = sourceInfos[i];
+      if(sourceInfo.kind == "video" && sourceInfo.facing == (isFront ? "front" : "back")) {
+        videoSourceId = sourceInfo.id;
+      }
     }
-  }
-  getUserMedia({
-    audio: true,
-    video: {
-      mandatory: {
-        minWidth: 500, // Provide your own width, height and frame rate here
-        minHeight: 300,
-        minFrameRate: 30
-      },
-      facingMode: (isFront ? "user" : "environment"),
-      optional: (videoSourceId ? [{sourceId: videoSourceId}] : [])
-    }
-  }, function (stream) {
+    return getUserMedia({
+      audio: true,
+      video: {
+        mandatory: {
+          minWidth: 500, // Provide your own width, height and frame rate here
+          minHeight: 300,
+          minFrameRate: 30
+        },
+        facingMode: (isFront ? "user" : "environment"),
+        optional: (videoSourceId ? [{sourceId: videoSourceId}] : [])
+      }
+    });
+  })
+  .then(stream => {
     console.log('dddd', stream);
-    callback(stream);
-  }, logError);
-});
+    return stream
+  })
+  .catch(logError);
 
-pc.createOffer(function(desc) {
-  pc.setLocalDescription(desc, function () {
+pc.createOffer()
+  .then(pc.setLocalDescription)
+  .then(() => {
     // Send pc.localDescription to peer
-  }, function(e) {});
-}, function(e) {});
+  })
+  .catch(logError);
 
 pc.onicecandidate = function (event) {
   // send event.candidate to peer
@@ -164,4 +169,3 @@ Use [react-native-incall-manager](https://github.com/zxcpoiu/react-native-incall
 
 ## Sponsorship
 This repository doesn't have a plan to get sponsorship.(This can be discussed afterwards by collaborators). If you would like to pay bounty to fix some bugs or get some features, be free to open a issue that adds `[BOUNTY]` category in title. Add other bounty website link like [this](https://www.bountysource.com) will be better.
-

--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -173,8 +173,8 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
       sessionDescription.toJSON(),
       this._peerConnectionId
     ).then(() => {
-        this.localDescription = sessionDescription;
-        return;
+      this.localDescription = sessionDescription;
+      return;
     });
   }
 
@@ -183,8 +183,8 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
       sessionDescription.toJSON(),
       this._peerConnectionId
     ).then(() => {
-        this.remoteDescription = sessionDescription;
-        return;
+      this.remoteDescription = sessionDescription;
+      return;
     });
   }
 

--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -195,7 +195,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
     );
   }
 
-  getStats(track, success, failure) {
+  getStats(track) {
     if (WebRTCModule.peerConnectionGetStats) {
       return WebRTCModule.peerConnectionGetStats(
         (track && track.id) || '',

--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -12,6 +12,7 @@ import RTCSessionDescription from './RTCSessionDescription';
 import RTCIceCandidate from './RTCIceCandidate';
 import RTCIceCandidateEvent from './RTCIceCandidateEvent';
 import RTCEvent from './RTCEvent';
+import withLegacyCallbacks from './withLegacyCallbacks';
 
 const {WebRTCModule} = NativeModules;
 
@@ -112,6 +113,13 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
         DEFAULT_PC_CONSTRAINTS,
         this._peerConnectionId);
     this._registerEvents();
+    // Allow for legacy callback usage
+    this.createOffer = withLegacyCallbacks(this.createOffer.bind(this), true);
+    this.createAnswer = withLegacyCallbacks(this.createAnswer.bind(this), true);
+    this.setLocalDescription = withLegacyCallbacks(this.setLocalDescription.bind(this), false, 1, 2);
+    this.setRemoteDescription = withLegacyCallbacks(this.setRemoteDescription.bind(this));
+    this.addIceCandidate = withLegacyCallbacks(this.addIceCandidate.bind(this));
+    this.getStats = withLegacyCallbacks(this.getStats.bind(this));
   }
 
   addStream(stream: MediaStream) {
@@ -142,93 +150,69 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
     return constraints;
   }
 
-  createOffer(successCallback: ?Function, failureCallback: ?Function, options) {
-    WebRTCModule.peerConnectionCreateOffer(
-        this._peerConnectionId,
-        this._mergeMediaConstraints(options),
-        (successful, data) => {
-          if (successful) {
-            successCallback(new RTCSessionDescription(data));
-          } else {
-            failureCallback(data); // TODO: convert to NavigatorUserMediaError
-          }
-        });
+  createOffer(options) {
+    return WebRTCModule.peerConnectionCreateOffer(
+      this._peerConnectionId,
+      this._mergeMediaConstraints(options)
+    ).then(data => new RTCSessionDescription(data));
   }
 
-  createAnswer(successCallback: ?Function, failureCallback: ?Function, options) {
-    WebRTCModule.peerConnectionCreateAnswer(
-        this._peerConnectionId,
-        this._mergeMediaConstraints(options),
-        (successful, data) => {
-          if (successful) {
-            successCallback(new RTCSessionDescription(data));
-          } else {
-            failureCallback(data);
-          }
-        });
+  createAnswer(options) {
+    return WebRTCModule.peerConnectionCreateAnswer(
+      this._peerConnectionId,
+      this._mergeMediaConstraints(options)
+    ).then(data => new RTCSessionDescription(data));
   }
 
   setConfiguration(configuration) {
     WebRTCModule.peerConnectionSetConfiguration(configuration, this._peerConnectionId);
   }
 
-  setLocalDescription(sessionDescription: RTCSessionDescription, success: ?Function, failure: ?Function, constraints) {
-    WebRTCModule.peerConnectionSetLocalDescription(sessionDescription.toJSON(), this._peerConnectionId, (successful, data) => {
-      if (successful) {
+  setLocalDescription(sessionDescription: RTCSessionDescription, constraints) {
+    return WebRTCModule.peerConnectionSetLocalDescription(
+      sessionDescription.toJSON(),
+      this._peerConnectionId
+    ).then(() => {
         this.localDescription = sessionDescription;
-        success();
-      } else {
-        failure(data);
-      }
+        return;
     });
   }
 
-  setRemoteDescription(sessionDescription: RTCSessionDescription, success: ?Function, failure: ?Function) {
-    WebRTCModule.peerConnectionSetRemoteDescription(sessionDescription.toJSON(), this._peerConnectionId, (successful, data) => {
-      if (successful) {
+  setRemoteDescription(sessionDescription: RTCSessionDescription) {
+    return WebRTCModule.peerConnectionSetRemoteDescription(
+      sessionDescription.toJSON(),
+      this._peerConnectionId
+    ).then(() => {
         this.remoteDescription = sessionDescription;
-        success();
-      } else {
-        failure(data);
-      }
+        return;
     });
   }
 
-  addIceCandidate(candidate, success, failure) { // TODO: success, failure
-    WebRTCModule.peerConnectionAddICECandidate(candidate.toJSON(), this._peerConnectionId, (successful) => {
-      if (successful) {
-        success && success();
-      } else {
-        failure && failure();
-      }
-    });
+  addIceCandidate(candidate) { // TODO: success, failure
+    return WebRTCModule.peerConnectionAddICECandidate(
+      candidate.toJSON(),
+      this._peerConnectionId
+    );
   }
 
-  getStats(track, success, failure) {
-    if (WebRTCModule.peerConnectionGetStats) {
-      WebRTCModule.peerConnectionGetStats(
-        (track && track.id) || '',
-        this._peerConnectionId,
-        stats => {
-          if (success) {
-            // It turns out that on Android it is faster to construct a single
-            // JSON string representing the array of StatsReports and have it
-            // pass through the React Native bridge rather than the array of
-            // StatsReports.
-            if (typeof stats === 'string') {
-              try {
-                stats = JSON.parse(stats);
-              } catch (e) {
-                failure(e);
-                return;
-              }
-            }
-            success(stats);
-          }
-        });
-    } else {
-      console.warn('RTCPeerConnection getStats not supported');
-    }
+  getStats(track) {
+    return WebRTCModule.peerConnectionGetStats(
+      (track && track.id) || '',
+      this._peerConnectionId
+    ).then(stats => {
+      // It turns out that on Android it is faster to construct a single
+      // JSON string representing the array of StatsReports and have it
+      // pass through the React Native bridge rather than the array of
+      // StatsReports.
+      if (typeof stats === 'string') {
+        try {
+          stats = JSON.parse(stats);
+        } catch (e) {
+          throw e;
+        }
+      }
+      return stats;
+    });
   }
 
   getRemoteStreams() {

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -270,7 +270,8 @@ class GetUserMediaImpl {
                     // name attribute has the value NotAllowedError."
                     promise.reject("DOMException", "NotAllowedError");
                 }
-            });
+            }
+        );
     }
 
     /**

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -194,15 +194,14 @@ class GetUserMediaImpl {
      */
     void getUserMedia(
             final ReadableMap constraints,
-            final Callback successCallback,
-            final Callback errorCallback,
+            final Promise promise,
             final MediaStream mediaStream) {
         // TODO: change getUserMedia constraints format to support new syntax
         //   constraint format seems changed, and there is no mandatory any more.
         //   and has a new syntax/attrs to specify resolution
         //   should change `parseConstraints()` according
         //   see: https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraints
- 
+
         final ArrayList<String> requestPermissions = new ArrayList<>();
 
         if (constraints.hasKey("audio")) {
@@ -241,7 +240,7 @@ class GetUserMediaImpl {
         // requestedMediaTypes is the empty set, the method invocation fails
         // with a TypeError.
         if (requestPermissions.isEmpty()) {
-            errorCallback.invoke(
+            promise.reject(
                 "TypeError",
                 "constraints requests no media types");
             return;
@@ -256,8 +255,7 @@ class GetUserMediaImpl {
 
                     getUserMedia(
                         constraints,
-                        successCallback,
-                        errorCallback,
+                        promise,
                         mediaStream,
                         grantedPermissions);
                 }
@@ -269,7 +267,7 @@ class GetUserMediaImpl {
                     // getUserMedia() algorithm, if the user has denied
                     // permission, fail "with a new DOMException object whose
                     // name attribute has the value NotAllowedError."
-                    errorCallback.invoke("DOMException", "NotAllowedError");
+                    promise.reject("DOMException", "NotAllowedError");
                 }
             });
     }
@@ -281,8 +279,7 @@ class GetUserMediaImpl {
      */
     private void getUserMedia(
             ReadableMap constraints,
-            Callback successCallback,
-            Callback errorCallback,
+            Promise promise,
             MediaStream mediaStream,
             List<String> grantedPermissions) {
         MediaStreamTrack[] tracks = new MediaStreamTrack[2];
@@ -302,13 +299,14 @@ class GetUserMediaImpl {
              // specified by
              // https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia
              // with respect to distinguishing the various causes of failure.
-             errorCallback.invoke(
+             promise.reject(
                  /* type */ null,
                  "Failed to create new track");
              return;
         }
 
         WritableArray tracks_ = Arguments.createArray();
+        WritableArray successResult = Arguments.createArray();
 
         for (MediaStreamTrack track : tracks) {
             if (track == null) {
@@ -326,7 +324,7 @@ class GetUserMediaImpl {
 
             WritableMap track_ = Arguments.createMap();
             String kind = track.kind();
- 
+
             track_.putBoolean("enabled", track.enabled());
             track_.putString("id", id);
             track_.putString("kind", kind);
@@ -341,7 +339,9 @@ class GetUserMediaImpl {
         Log.d(TAG, "MediaStream id: " + streamId);
         webRTCModule.mMediaStreams.put(streamId, mediaStream);
 
-        successCallback.invoke(streamId, tracks_);
+        successResult.pushString(streamId);
+        successResult.pushArray(tracks);
+        promise.resolve(successResult);
     }
 
     private VideoTrack getUserVideo(ReadableMap constraints) {
@@ -403,7 +403,7 @@ class GetUserMediaImpl {
                 : DEFAULT_FPS;
 
         videoCapturer.startCapture(width, height, fps);
-  
+
         String trackId = webRTCModule.getNextTrackUUID();
         mVideoCapturers.put(trackId, videoCapturer);
 

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.Promise;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -340,7 +341,7 @@ class GetUserMediaImpl {
         webRTCModule.mMediaStreams.put(streamId, mediaStream);
 
         successResult.pushString(streamId);
-        successResult.pushArray(tracks);
+        successResult.pushArray(tracks_);
         promise.resolve(successResult);
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -11,6 +11,7 @@ import android.util.SparseArray;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -182,7 +183,7 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         }
     }
 
-    void getStats(String trackId, final Callback cb) {
+    void getStats(String trackId, final Promise promise) {
         MediaStreamTrack track = null;
         if (trackId == null
                 || trackId.isEmpty()
@@ -192,7 +193,7 @@ class PeerConnectionObserver implements PeerConnection.Observer {
                     new StatsObserver() {
                         @Override
                         public void onComplete(StatsReport[] reports) {
-                            cb.invoke(convertWebRTCStats(reports));
+                            promise.resolve(convertWebRTCStats(reports));
                         }
                     },
                     track);

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -82,8 +82,8 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
 
 // TODO: Use RCTConvert for constraints ...
 RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
-               successCallback:(RCTResponseSenderBlock)successCallback
-                 errorCallback:(RCTResponseSenderBlock)errorCallback) {
+               resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
   // Initialize RTCMediaStream with a unique label in order to allow multiple
   // RTCMediaStream instances initialized by multiple getUserMedia calls to be
   // added to 1 RTCPeerConnection instance. As suggested by
@@ -116,10 +116,10 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
         }
       }
       self.localStreams[mediaStreamId] = mediaStream;
-      successCallback(@[ mediaStreamId, tracks ]);
+      resolve(@[ mediaStreamId, tracks ]);
     }
     errorCallback:^ (NSString *errorType, NSString *errorMessage) {
-      errorCallback(@[ errorType, errorMessage ]);
+      reject(errorType, errorMessage, nil);
     }
     mediaStream:mediaStream];
 }
@@ -153,7 +153,7 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
          mediaStream:(RTCMediaStream *)mediaStream {
   // If mediaStream contains no audioTracks and the constraints request such a
   // track, then run an iteration of the getUserMedia() algorithm to obtain
-  // local audio content. 
+  // local audio content.
   if (mediaStream.audioTracks.count == 0) {
     // constraints.audio
     id audioConstraints = constraints[@"audio"];
@@ -311,7 +311,8 @@ RCT_EXPORT_METHOD(mediaStreamRelease:(nonnull NSString *)streamID)
   }
 }
 
-RCT_EXPORT_METHOD(mediaStreamTrackGetSources:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(mediaStreamTrackGetSources:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
   NSMutableArray *sources = [NSMutableArray array];
   NSArray *videoDevices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
   for (AVCaptureDevice *device in videoDevices) {
@@ -331,7 +332,7 @@ RCT_EXPORT_METHOD(mediaStreamTrackGetSources:(RCTResponseSenderBlock)callback) {
                          @"kind": @"audio",
                          }];
   }
-  callback(@[sources]);
+  resolve(@[sources]);
 }
 
 RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSString *)streamID : (nonnull NSString *)trackID)

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -120,10 +120,10 @@ RCT_EXPORT_METHOD(peerConnectionCreateOffer:(nonnull NSNumber *)objectID
     offerForConstraints:[self parseMediaConstraints:constraints]
       completionHandler:^(RTCSessionDescription *sdp, NSError *error) {
         if (error) {
-            reject(@"CreateOfferFailed", error.userInfo[@"error"], error);
+          reject(@"CreateOfferFailed", error.userInfo[@"error"], error);
         } else {
-            NSString *type = [RTCSessionDescription stringForType:sdp.type];
-            resolve(@{@"sdp": sdp.sdp, @"type": type});
+          NSString *type = [RTCSessionDescription stringForType:sdp.type];
+          resolve(@{@"sdp": sdp.sdp, @"type": type});
         }
       }];
 }
@@ -140,14 +140,14 @@ RCT_EXPORT_METHOD(peerConnectionCreateAnswer:(nonnull NSNumber *)objectID
 
   [peerConnection
     answerForConstraints:[self parseMediaConstraints:constraints]
-       completionHandler:^(RTCSessionDescription *sdp, NSError *error) {
+      completionHandler:^(RTCSessionDescription *sdp, NSError *error) {
         if (error) {
-            reject(@"CreateAnswerFailed", error.userInfo[@"error"], error);
-         } else {
-           NSString *type = [RTCSessionDescription stringForType:sdp.type];
-           resolve(@{@"sdp": sdp.sdp, @"type": type});
-         }
-       }];
+          reject(@"CreateAnswerFailed", error.userInfo[@"error"], error);
+        } else {
+          NSString *type = [RTCSessionDescription stringForType:sdp.type];
+          resolve(@{@"sdp": sdp.sdp, @"type": type});
+        }
+      }];
 }
 
 RCT_EXPORT_METHOD(peerConnectionSetLocalDescription:(RTCSessionDescription *)sdp objectID:(nonnull NSNumber *)objectID resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
@@ -175,9 +175,9 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription:(RTCSessionDescription *)sd
 
   [peerConnection setRemoteDescription: sdp completionHandler: ^(NSError *error) {
     if (error) {
-        reject(@"SetRemoteDescriptionFailed", error.localizedDescription, error);
+      reject(@"SetRemoteDescriptionFailed", error.localizedDescription, error);
     } else {
-        resolve(nil);
+      resolve(nil);
     }
   }];
 }

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -108,7 +108,8 @@ RCT_EXPORT_METHOD(peerConnectionRemoveStream:(nonnull NSString *)streamID object
 
 RCT_EXPORT_METHOD(peerConnectionCreateOffer:(nonnull NSNumber *)objectID
                                 constraints:(NSDictionary *)constraints
-                                   callback:(RCTResponseSenderBlock)callback)
+                                   resolver:(RCTPromiseResolveBlock)resolve
+                                   rejecter:(RCTPromiseRejectBlock)reject)
 {
   RTCPeerConnection *peerConnection = self.peerConnections[objectID];
   if (!peerConnection) {
@@ -119,22 +120,18 @@ RCT_EXPORT_METHOD(peerConnectionCreateOffer:(nonnull NSNumber *)objectID
     offerForConstraints:[self parseMediaConstraints:constraints]
       completionHandler:^(RTCSessionDescription *sdp, NSError *error) {
         if (error) {
-          callback(@[
-            @(NO),
-            @{
-              @"type": @"CreateOfferFailed",
-              @"message": error.userInfo[@"error"]}
-          ]);
+            reject(@"CreateOfferFailed", error.userInfo[@"error"], error);
         } else {
-          NSString *type = [RTCSessionDescription stringForType:sdp.type];
-          callback(@[@(YES), @{@"sdp": sdp.sdp, @"type": type}]);
+            NSString *type = [RTCSessionDescription stringForType:sdp.type];
+            resolve(@{@"sdp": sdp.sdp, @"type": type});
         }
       }];
 }
 
 RCT_EXPORT_METHOD(peerConnectionCreateAnswer:(nonnull NSNumber *)objectID
                                  constraints:(NSDictionary *)constraints
-                                    callback:(RCTResponseSenderBlock)callback)
+                                    resolver:(RCTPromiseResolveBlock)resolve
+                                    rejecter:(RCTPromiseRejectBlock)reject)
 {
   RTCPeerConnection *peerConnection = self.peerConnections[objectID];
   if (!peerConnection) {
@@ -144,21 +141,16 @@ RCT_EXPORT_METHOD(peerConnectionCreateAnswer:(nonnull NSNumber *)objectID
   [peerConnection
     answerForConstraints:[self parseMediaConstraints:constraints]
        completionHandler:^(RTCSessionDescription *sdp, NSError *error) {
-         if (error) {
-           callback(@[
-             @(NO),
-             @{
-               @"type": @"CreateAnswerFailed",
-               @"message": error.userInfo[@"error"]}
-           ]);
+        if (error) {
+            reject(@"CreateAnswerFailed", error.userInfo[@"error"], error);
          } else {
            NSString *type = [RTCSessionDescription stringForType:sdp.type];
-           callback(@[@(YES), @{@"sdp": sdp.sdp, @"type": type}]);
+           resolve(@{@"sdp": sdp.sdp, @"type": type});
          }
        }];
 }
 
-RCT_EXPORT_METHOD(peerConnectionSetLocalDescription:(RTCSessionDescription *)sdp objectID:(nonnull NSNumber *)objectID callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(peerConnectionSetLocalDescription:(RTCSessionDescription *)sdp objectID:(nonnull NSNumber *)objectID resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   RTCPeerConnection *peerConnection = self.peerConnections[objectID];
   if (!peerConnection) {
@@ -167,16 +159,14 @@ RCT_EXPORT_METHOD(peerConnectionSetLocalDescription:(RTCSessionDescription *)sdp
 
   [peerConnection setLocalDescription:sdp completionHandler: ^(NSError *error) {
     if (error) {
-      id errorResponse = @{@"name": @"SetLocalDescriptionFailed",
-                           @"message": error.localizedDescription};
-      callback(@[@(NO), errorResponse]);
+      reject(@"SetLocalDescriptionFailed", error.localizedDescription, error);
     } else {
-      callback(@[@(YES)]);
+      resolve(nil);
     }
   }];
 }
 
-RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription:(RTCSessionDescription *)sdp objectID:(nonnull NSNumber *)objectID callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription:(RTCSessionDescription *)sdp objectID:(nonnull NSNumber *)objectID resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   RTCPeerConnection *peerConnection = self.peerConnections[objectID];
   if (!peerConnection) {
@@ -185,16 +175,14 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription:(RTCSessionDescription *)sd
 
   [peerConnection setRemoteDescription: sdp completionHandler: ^(NSError *error) {
     if (error) {
-      id errorResponse = @{@"name": @"SetRemoteDescriptionFailed",
-                           @"message": error.localizedDescription};
-      callback(@[@(NO), errorResponse]);
+        reject(@"SetRemoteDescriptionFailed", error.localizedDescription, error);
     } else {
-      callback(@[@(YES)]);
+        resolve(nil);
     }
   }];
 }
 
-RCT_EXPORT_METHOD(peerConnectionAddICECandidate:(RTCIceCandidate*)candidate objectID:(nonnull NSNumber *)objectID callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(peerConnectionAddICECandidate:(RTCIceCandidate*)candidate objectID:(nonnull NSNumber *)objectID resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   RTCPeerConnection *peerConnection = self.peerConnections[objectID];
   if (!peerConnection) {
@@ -203,7 +191,7 @@ RCT_EXPORT_METHOD(peerConnectionAddICECandidate:(RTCIceCandidate*)candidate obje
 
   [peerConnection addIceCandidate:candidate];
   NSLog(@"addICECandidateresult: %@", candidate);
-  callback(@[@true]);
+  resolve(nil);
 }
 
 RCT_EXPORT_METHOD(peerConnectionClose:(nonnull NSNumber *)objectID)
@@ -245,7 +233,7 @@ RCT_EXPORT_METHOD(peerConnectionClose:(nonnull NSNumber *)objectID)
   [dataChannels removeAllObjects];
 }
 
-RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID objectID:(nonnull NSNumber *)objectID callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID objectID:(nonnull NSNumber *)objectID resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   RTCPeerConnection *peerConnection = self.peerConnections[objectID];
   if (!peerConnection) {
@@ -278,7 +266,7 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID objectID:(n
                                    @"values": valuesCollection,
                                    }];
     }
-    callback(@[statsCollection]);
+    resolve(@[statsCollection]);
   }];
 }
 

--- a/withLegacyCallbacks.js
+++ b/withLegacyCallbacks.js
@@ -1,0 +1,27 @@
+module.exports = withLegacyCallbacks;
+
+/**
+* Returns a Promise and legacy callbacks compatible function
+* @param {Function} method - The function to make Promise and legacy callbacks compatible
+* @param {Boolean} [callbackFirst] - Indicate whether or not the success and failure callbacks are the firsts arguments
+* @param {Number} [successIndex] - Index of the success callback
+* @param {Number} [failureIndex] - Index of the failure callback
+* @returns {Function}
+*/
+function withLegacyCallbacks(method, callbackFirst, successIndex, failureIndex) {
+  return function(...args) {
+    const successPos = successIndex || callbackFirst ? 0 : args.length - 2;
+    const failurePos = failureIndex || callbackFirst ? 1 : args.length - 1;
+    const success = args[successPos];
+    const failure = args[failurePos];
+    // If legacy callbacks
+    if (typeof success === 'function' &&
+        typeof failure === 'function') {
+      const newArgs = args.filter(item => item !== success && item !== failure);
+      return method(...newArgs)
+        .then(success)
+        .catch(failure);
+    }
+    return method(...args);
+  };
+}

--- a/withLegacyCallbacks.js
+++ b/withLegacyCallbacks.js
@@ -10,8 +10,8 @@ module.exports = withLegacyCallbacks;
 */
 function withLegacyCallbacks(method, callbackFirst, successIndex, failureIndex) {
   return function(...args) {
-    const successPos = successIndex || callbackFirst ? 0 : args.length - 2;
-    const failurePos = failureIndex || callbackFirst ? 1 : args.length - 1;
+    const successPos = successIndex || (callbackFirst ? 0 : args.length - 2);
+    const failurePos = failureIndex || (callbackFirst ? 1 : args.length - 1);
     const success = args[successPos];
     const failure = args[failurePos];
     // If legacy callbacks


### PR DESCRIPTION
This PR adds Promise support as mentioned in #53.

## Promise support 
- getUserMedia
- MediaStreamTrack.getSources
- createOffer
- createAnswer
- setLocalDescription
- setRemoteDescription
- addIceCandidate
- getStats

## Javascript
Using @philikon's idea, I defined a ``withLegacyCallbacks`` function to allow the user to choose between the callbacks and the promise version.

## Native
All the corresponding native methods now returns promises.

## Documentation
The README has been updated with examples using promises instead of callbacks.