### PR TITLE
ios: generate reactTag for remote streams/tracks

### DIFF
--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -368,17 +368,20 @@ RCT_CUSTOM_VIEW_PROPERTY(objectFit, NSString *, RTCVideoView) {
   view.objectFit = e;
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(streamURL, NSNumber, RTCVideoView) {
+RCT_CUSTOM_VIEW_PROPERTY(streamURL, NSString, RTCVideoView) {
   RTCVideoTrack *videoTrack;
 
   if (json) {
     NSString *streamId = (NSString *)json;
 
     WebRTCModule *module = [self.bridge moduleForName:@"WebRTCModule"];
-    RTCMediaStream *stream = module.mediaStreams[streamId];
-    NSArray *videoTracks = stream.videoTracks;
+    RTCMediaStream *stream = module.localStreams[streamId];
+    if (!stream) {
+      stream = module.remoteStreams[streamId];
+    }
+    NSArray *videoTracks = stream ? stream.videoTracks : nil;
 
-    videoTrack = videoTracks.count ? videoTracks[0] : nil;
+    videoTrack = videoTracks && videoTracks.count ? videoTracks[0] : nil;
   } else {
     videoTrack = nil;
   }

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -22,7 +22,9 @@
 @property (nonatomic, strong) RTCPeerConnectionFactory *peerConnectionFactory;
 
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, RTCPeerConnection *> *peerConnections;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *mediaStreams;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *tracks;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *localStreams;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *localTracks;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *remoteStreams;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *remoteTracks;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -29,18 +29,24 @@
 //    [RTCPeerConnectionFactory initializeSSL];
 
     _peerConnections = [NSMutableDictionary new];
-    _mediaStreams = [NSMutableDictionary new];
-    _tracks = [NSMutableDictionary new];
+    _remoteStreams = [NSMutableDictionary new];
+    _remoteTracks = [NSMutableDictionary new];
+    _localStreams = [NSMutableDictionary new];
+    _localTracks = [NSMutableDictionary new];
   }
   return self;
 }
 
 - (void)dealloc
 {
-  [_tracks removeAllObjects];
-  _tracks = nil;
-  [_mediaStreams removeAllObjects];
-  _mediaStreams = nil;
+  [_remoteTracks removeAllObjects];
+  _remoteTracks = nil;
+  [_remoteStreams removeAllObjects];
+  _remoteStreams = nil;
+  [_localTracks removeAllObjects];
+  _localTracks = nil;
+  [_localStreams removeAllObjects];
+  _localStreams = nil;
 
   for (NSNumber *peerConnectionId in _peerConnections) {
     RTCPeerConnection *peerConnection = _peerConnections[peerConnectionId];


### PR DESCRIPTION
Will generate react tags for remote streams and tracks in the form of
{RTCPeerConnection react tag}_{stream id|track id}

This allows to receive streams/tracks with the same IDs through different PeerConnections.

Required for "peer to peer".