### PR TITLE
revert: ios: set default video constraints to 720p

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -39,13 +39,9 @@ typedef void (^NavigatorUserMediaErrorCallback)(NSString *errorType, NSString *e
 typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
 
 - (RTCMediaConstraints *)defaultMediaStreamConstraints {
-  NSDictionary *mandatoryConstraints
-      = @{ kRTCMediaConstraintsMinWidth     : @"1280",
-           kRTCMediaConstraintsMinHeight    : @"720",
-           kRTCMediaConstraintsMinFrameRate : @"30" };
   RTCMediaConstraints* constraints =
   [[RTCMediaConstraints alloc]
-   initWithMandatoryConstraints:mandatoryConstraints
+   initWithMandatoryConstraints:nil
    optionalConstraints:nil];
   return constraints;
 }


### PR DESCRIPTION
By default the front camera  will be opened in 480p otherwise. This
aligns with the behavior in Android after
https://github.com/oney/react-native-webrtc/commit/f89f43c1799c2b65b99aa5d7a0114e0acf8eaf8d (reverted from commit 063c9c4b84febcf4594c76641089d58aa0b11196)