### PR TITLE
handle RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModulePackage.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModulePackage.java
@@ -24,7 +24,7 @@ public class WebRTCModulePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
RN 0.47 removed createJSModules from ReactPackage [commit](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)