### PR TITLE
[Android] Fix leaking remote streams

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -322,7 +322,7 @@ class GetUserMediaImpl {
             } else {
                 mediaStream.addTrack((VideoTrack) track);
             }
-            webRTCModule.mMediaStreamTracks.put(id, track);
+            webRTCModule.localMediaStreamTracks.put(id, track);
 
             WritableMap track_ = Arguments.createMap();
             String kind = track.kind();
@@ -339,7 +339,7 @@ class GetUserMediaImpl {
         String streamId = mediaStream.label();
 
         Log.d(TAG, "MediaStream id: " + streamId);
-        webRTCModule.mMediaStreams.put(streamId, mediaStream);
+        webRTCModule.localMediaStreams.put(streamId, mediaStream);
 
         successCallback.invoke(streamId, tracks_);
     }

--- a/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
@@ -63,7 +63,7 @@ public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
       mediaStream = null;
     } else {
       WebRTCModule module = mContext.getNativeModule(WebRTCModule.class);
-      mediaStream = module.mMediaStreams.get(streamURL);
+      mediaStream = module.getStreamForReactTag(streamURL);
     }
     view.setStream(mediaStream);
   }

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -617,7 +617,6 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         }
         for (VideoTrack track : mediaStream.videoTracks) {
             mMediaStreamTracks.remove(track.id());
-            getUserMediaImpl.removeVideoCapturer(track.id());
         }
         for (AudioTrack track : mediaStream.audioTracks) {
             mMediaStreamTracks.remove(track.id());

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -615,12 +615,6 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         if (mediaStream == null) {
             return null;
         }
-        for (VideoTrack track : mediaStream.videoTracks) {
-            mMediaStreamTracks.remove(track.id());
-        }
-        for (AudioTrack track : mediaStream.audioTracks) {
-            mMediaStreamTracks.remove(track.id());
-        }
         String reactTag = null;
         for (Iterator<Map.Entry<String, MediaStream>> i
                     = mMediaStreams.entrySet().iterator();

--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -372,16 +372,16 @@ RCT_CUSTOM_VIEW_PROPERTY(streamURL, NSString, RTCVideoView) {
   RTCVideoTrack *videoTrack;
 
   if (json) {
-    NSString *streamId = (NSString *)json;
+    NSString *streamReactTag = (NSString *)json;
 
     WebRTCModule *module = [self.bridge moduleForName:@"WebRTCModule"];
-    RTCMediaStream *stream = module.localStreams[streamId];
-    if (!stream) {
-      stream = module.remoteStreams[streamId];
-    }
+    RTCMediaStream *stream = [module streamForTag:streamReactTag];
     NSArray *videoTracks = stream ? stream.videoTracks : nil;
 
     videoTrack = videoTracks && videoTracks.count ? videoTracks[0] : nil;
+    if (!videoTrack) {
+      NSLog(@"No video stream for react tag: %@", streamReactTag);
+    }
   } else {
     videoTrack = nil;
   }

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.h
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.h
@@ -13,6 +13,8 @@
 
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, RTCDataChannel *> *dataChannels;
 @property (nonatomic, strong) NSNumber *reactTag;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *remoteStreams;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *remoteTracks;
 
 @end
 

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -24,7 +24,7 @@
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, RTCPeerConnection *> *peerConnections;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *localStreams;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *localTracks;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *remoteStreams;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *remoteTracks;
+
+- (RTCMediaStream*)streamForTag:(NSString*)reactTag;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -12,6 +12,7 @@
 #import <React/RCTUtils.h>
 
 #import "WebRTCModule.h"
+#import "WebRTCModule+RTCPeerConnection.h"
 
 @interface WebRTCModule ()
 
@@ -29,20 +30,29 @@
 //    [RTCPeerConnectionFactory initializeSSL];
 
     _peerConnections = [NSMutableDictionary new];
-    _remoteStreams = [NSMutableDictionary new];
-    _remoteTracks = [NSMutableDictionary new];
     _localStreams = [NSMutableDictionary new];
     _localTracks = [NSMutableDictionary new];
   }
   return self;
 }
 
+- (RTCMediaStream*)streamForTag:(NSString*)reactTag
+{
+    RTCMediaStream *stream = _localStreams[reactTag];
+    if (!stream) {
+        for (NSNumber *peerConnectionId in _peerConnections) {
+            RTCPeerConnection *peerConnection = _peerConnections[peerConnectionId];
+            stream = peerConnection.remoteStreams[reactTag];
+            if (stream) {
+                break;
+            }
+        }
+    }
+    return stream;
+}
+
 - (void)dealloc
 {
-  [_remoteTracks removeAllObjects];
-  _remoteTracks = nil;
-  [_remoteStreams removeAllObjects];
-  _remoteStreams = nil;
   [_localTracks removeAllObjects];
   _localTracks = nil;
   [_localStreams removeAllObjects];


### PR DESCRIPTION
Remote streams were leaking on Android, because when a peer connection was closed tracks were not removed from WebRTCModule. This PR stores tracks and streams in PeerConnectionObserver. Also adapts the iOS part to use similar strategy instead of special react tag syntax.