### PR TITLE
Migrate to 'prop-types' module

### DIFF
--- a/RTCView.js
+++ b/RTCView.js
@@ -5,7 +5,7 @@ import {
   NativeModules,
   requireNativeComponent,
 } from 'react-native';
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 
 const {WebRTCModule} = NativeModules;
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "dependencies": {
     "base64-js": "^1.1.2",
-    "event-target-shim": "^1.0.5"
+    "event-target-shim": "^1.0.5",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "react-native": ">=0.40.0"


### PR DESCRIPTION
Fixes a PropTypes deprecation warning that keeps getting logged, see: https://facebook.github.io/react/warnings/dont-call-proptypes.html