### PR TITLE
WIP: Video constraints (parsing in JS)

### DIFF
--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -2,6 +2,7 @@
 
 import EventTarget from 'event-target-shim';
 import {DeviceEventEmitter, NativeModules} from 'react-native';
+import * as RTCUtil from './RTCUtil';
 
 import MediaStream from './MediaStream';
 import MediaStreamEvent from './MediaStreamEvent';
@@ -130,37 +131,17 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
     WebRTCModule.peerConnectionRemoveStream(stream.reactTag, this._peerConnectionId);
   }
 
-  /**
-   * Merge custom constraints with the default one. The custom one take precedence.
-   *
-   * @param {Object} options - webrtc constraints
-   * @return {Object} constraints - merged webrtc constraints
-   */
-  _mergeMediaConstraints(options) {
-    const constraints = Object.assign({}, DEFAULT_SDP_CONSTRAINTS);
-    if (options) {
-      if (options.mandatory) {
-        constraints.mandatory = {...constraints.mandatory, ...options.mandatory};
-      }
-      if (options.optional && Array.isArray(options.optional)) {
-        // `optional` is an array, webrtc only finds first and ignore the rest if duplicate.
-        constraints.optional = options.optional.concat(constraints.optional);
-      }
-    }
-    return constraints;
-  }
-
   createOffer(options) {
     return WebRTCModule.peerConnectionCreateOffer(
       this._peerConnectionId,
-      this._mergeMediaConstraints(options)
+      RTCUtil.mergeMediaConstraints(options, DEFAULT_SDP_CONSTRAINTS)
     ).then(data => new RTCSessionDescription(data));
   }
 
   createAnswer(options) {
     return WebRTCModule.peerConnectionCreateAnswer(
       this._peerConnectionId,
-      this._mergeMediaConstraints(options)
+      RTCUtil.mergeMediaConstraints(options, DEFAULT_SDP_CONSTRAINTS)
     ).then(data => new RTCSessionDescription(data));
   }
 

--- a/RTCUtil.js
+++ b/RTCUtil.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Merge custom constraints with the default one. The custom one take precedence.
+ *
+ * @param {Object} custom - custom webrtc constraints
+ * @param {Object} def - default webrtc constraints
+ * @return {Object} constraints - merged webrtc constraints
+ */
+export function mergeMediaConstraints(custom, def) {
+  const constraints = (def ? Object.assign({}, def) : {});
+  if (custom) {
+    if (custom.mandatory) {
+      constraints.mandatory = {...constraints.mandatory, ...custom.mandatory};
+    }
+    if (custom.optional && Array.isArray(custom.optional)) {
+      // `optional` is an array, webrtc only finds first and ignore the rest if duplicate.
+      constraints.optional = custom.optional.concat(constraints.optional);
+    }
+  }
+  return constraints;
+}

--- a/RTCUtil.js
+++ b/RTCUtil.js
@@ -17,6 +17,9 @@ export function mergeMediaConstraints(custom, def) {
       // `optional` is an array, webrtc only finds first and ignore the rest if duplicate.
       constraints.optional = custom.optional.concat(constraints.optional);
     }
+    if (custom.facingMode) {
+      constraints.facingMode = custom.facingMode.toString(); // string, 'user' or the default 'environment'
+    }
   }
   return constraints;
 }

--- a/getUserMedia.js
+++ b/getUserMedia.js
@@ -17,6 +17,7 @@ const DEFAULT_VIDEO_CONSTRAINTS = {
     minHeight: '720',
     minFrameRate: '30',
   },
+  facingMode: "environment",
   optional: [],
 };
 

--- a/getUserMedia.js
+++ b/getUserMedia.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import {NativeModules} from 'react-native';
+import {Platform, NativeModules} from 'react-native';
+import * as RTCUtil from './RTCUtil';
 
 import MediaStream from './MediaStream';
 import MediaStreamError from './MediaStreamError';
@@ -8,6 +9,52 @@ import MediaStreamTrack from './MediaStreamTrack';
 import withLegacyCallbacks from './withLegacyCallbacks';
 
 const {WebRTCModule} = NativeModules;
+
+// native side consume string eventually
+const DEFAULT_VIDEO_CONSTRAINTS = {
+  mandatory: {
+    minWidth: '1280',
+    minHeight: '720',
+    minFrameRate: '30',
+  },
+  optional: [],
+};
+
+function getDefaultMediaConstraints(mediaType) {
+  return (mediaType === 'audio'
+      ? true // no audio default constraint currently
+      : RTCUtil.mergeMediaConstraints(DEFAULT_VIDEO_CONSTRAINTS));
+}
+
+// this will make sure we have the correct constraint structure
+// TODO: support width/height range and the latest param names according to spec
+//   media constraints param name should follow spec. then we need a function to convert these `js names`
+//   into the real `const name that native defined` on both iOS and Android.
+// see mediaTrackConstraints: https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackconstraints
+function parseMediaConstraints(customConstraints, mediaType) {
+  return (mediaType === 'audio'
+      ? RTCUtil.mergeMediaConstraints(customConstraints, {}) // no audio default constraint currently
+      : RTCUtil.mergeMediaConstraints(customConstraints, DEFAULT_VIDEO_CONSTRAINTS));
+}
+
+// this will make sure we have the correct value type
+function normalizeMediaConstraints(constraints, mediaType) {
+  if (mediaType === 'audio') {
+    ; // to be added
+  } else {
+    // NOTE: android only support minXXX currently
+    for (const param of ['minWidth', 'minHeight', 'minFrameRate', 'maxWidth', 'maxHeight', 'maxFrameRate', ]) {
+      if (constraints.mandatory.hasOwnProperty(param)) {
+        // convert to correct type here so that native can consume directly without worries.
+        constraints.mandatory[param] = (Platform.OS === 'ios'
+            ? constraints.mandatory[param].toString() // ios consumes string
+            : parseInt(constraints.mandatory[param])); // android eats integer
+      }
+    }
+  }
+
+  return constraints;
+}
 
 export default withLegacyCallbacks(constraints => {
   // According to
@@ -26,11 +73,21 @@ export default withLegacyCallbacks(constraints => {
       const typeofMediaTypeConstraints = typeof mediaTypeConstraints;
       if (typeofMediaTypeConstraints !== 'undefined') {
         if (typeofMediaTypeConstraints === 'boolean') {
-          mediaTypeConstraints && ++requestedMediaTypes;
+          if (mediaTypeConstraints) {
+            ++requestedMediaTypes;
+            constraints[mediaType] = getDefaultMediaConstraints(mediaType);
+          }
         } else if (typeofMediaTypeConstraints == 'object') {
+          // Note: object constraints for audio is not implemented in native side
           ++requestedMediaTypes;
+          constraints[mediaType] = parseMediaConstraints(constraints[mediaType], mediaType);
         } else {
           throw new TypeError('constraints.' + mediaType + ' is neither a boolean nor a dictionary');
+        }
+
+        // final check constraints and convert value to native accepted type
+        if (typeof constraints[mediaType] === 'object') {
+          constraints[mediaType] = normalizeMediaConstraints(constraints[mediaType], mediaType);
         }
       }
     }

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -38,18 +38,6 @@ typedef void (^NavigatorUserMediaErrorCallback)(NSString *errorType, NSString *e
  */
 typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
 
-- (RTCMediaConstraints *)defaultMediaStreamConstraints {
-  NSDictionary *mandatoryConstraints
-      = @{ kRTCMediaConstraintsMinWidth     : @"1280",
-           kRTCMediaConstraintsMinHeight    : @"720",
-           kRTCMediaConstraintsMinFrameRate : @"30" };
-  RTCMediaConstraints* constraints =
-  [[RTCMediaConstraints alloc]
-   initWithMandatoryConstraints:mandatoryConstraints
-   optionalConstraints:nil];
-  return constraints;
-}
-
 /**
  * Initializes a new {@link RTCAudioTrack} which satisfies specific constraints,
  * adds it to a specific {@link RTCMediaStream}, and reports success to a
@@ -268,8 +256,10 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
   }
 
   if (videoDevice) {
-    // TODO: Actually use constraints...
-    RTCAVFoundationVideoSource *videoSource = [self.peerConnectionFactory avFoundationVideoSourceWithConstraints:[self defaultMediaStreamConstraints]];
+    // we handle all the constraints parsing in js side. just consume it.
+    // TODO: support optional constraints
+    RTCMediaConstraints* finalConstraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:videoConstraints[@"mandatory"] optionalConstraints:nil];
+    RTCAVFoundationVideoSource *videoSource = [self.peerConnectionFactory avFoundationVideoSourceWithConstraints:finalConstraints];
     // FIXME The effort above to find a videoDevice value which satisfies the
     // specified constraints was pretty much wasted. Salvage facingMode for
     // starters because it is kind of a common and hence important feature on


### PR DESCRIPTION
This is a follow up of #140 and #288 and #359 

## The main purpose is to:

1. support constraints parsing
2. do it at JS side to reduce native code's complexity and easier to maintain / test.

original we supports `minWidth` / `minHeight` / `minFrameRate`, now add `maxXXX` for ios.
android doesn't consume `maxXXX` in current version.

## Test / Review

I don't have any video use cases, these code is not tested / compiled.
This is meant to reduce discussion time as a demo.

@RangerMauve @ramneekhanda or any folks
please help to review / test to see if it works.

And fire a fix PR to this branch directly.

thanks!!