### PR TITLE
Deep clone default constraints

### DIFF
--- a/RTCUtil.js
+++ b/RTCUtil.js
@@ -7,8 +7,13 @@
  * @param {Object} def - default webrtc constraints
  * @return {Object} constraints - merged webrtc constraints
  */
+
+ function _deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj))
+}
+
 export function mergeMediaConstraints(custom, def) {
-  const constraints = (def ? Object.assign({}, def) : {});
+  let constraints = _deepClone(def)
   if (custom) {
     if (custom.mandatory) {
       constraints.mandatory = {...constraints.mandatory, ...custom.mandatory};

--- a/RTCUtil.js
+++ b/RTCUtil.js
@@ -1,19 +1,24 @@
 'use strict';
 
 /**
+ * Internal util for deep clone object. Object.assign() only does a shallow copy
+ *
+ * @param {Object} obj - object to be cloned
+ * @return {Object} cloned obj
+ */
+function _deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+/**
  * Merge custom constraints with the default one. The custom one take precedence.
  *
  * @param {Object} custom - custom webrtc constraints
  * @param {Object} def - default webrtc constraints
  * @return {Object} constraints - merged webrtc constraints
  */
-
- function _deepClone(obj) {
-  return JSON.parse(JSON.stringify(obj))
-}
-
 export function mergeMediaConstraints(custom, def) {
-  let constraints = _deepClone(def)
+  const constraints = (def ? _deepClone(def) : {});
   if (custom) {
     if (custom.mandatory) {
       constraints.mandatory = {...constraints.mandatory, ...custom.mandatory};

--- a/getUserMedia.js
+++ b/getUserMedia.js
@@ -34,7 +34,7 @@ function getDefaultMediaConstraints(mediaType) {
 // see mediaTrackConstraints: https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackconstraints
 function parseMediaConstraints(customConstraints, mediaType) {
   return (mediaType === 'audio'
-      ? RTCUtil.mergeMediaConstraints(customConstraints, {}) // no audio default constraint currently
+      ? RTCUtil.mergeMediaConstraints(customConstraints) // no audio default constraint currently
       : RTCUtil.mergeMediaConstraints(customConstraints, DEFAULT_VIDEO_CONSTRAINTS));
 }
 


### PR DESCRIPTION
I used `JSON.parse(JSON.stringify(obj))` because `Object.assign` does not clone the object deeply causing an error on the second usage of `getUserMedia` or `RTCPeerConnection.createOffer`.

Related issues: #116 #101 #104 

Cheers!