### PR TITLE
muting/unmuting remote streams

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -535,7 +535,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void mediaStreamTrackSetEnabled(final String id, final boolean enabled) {
-        MediaStreamTrack track = localTracks.get(id);
+        MediaStreamTrack track = getTrackForId(id);
         if (track == null) {
             Log.d(TAG, "mediaStreamTrackSetEnabled() track is null");
             return;

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -343,9 +343,24 @@ RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSString *)streamID : (nonnul
   }
 }
 
+- (RTCMediaStreamTrack*)trackForId:(NSString*)trackId
+{
+  RTCMediaStreamTrack *track = self.localTracks[trackId];
+  if (!track) {
+    for (NSNumber *peerConnectionId in self.peerConnections) {
+      RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+      track = peerConnection.remoteTracks[trackId];
+      if (track) {
+        break;
+      }
+    }
+  }
+  return track;
+}
+
 RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled:(nonnull NSString *)trackID : (BOOL)enabled)
 {
-  RTCMediaStreamTrack *track = self.localTracks[trackID];
+  RTCMediaStreamTrack *track = [self trackForId:trackID];
   if (track && track.isEnabled != enabled) {
     track.isEnabled = enabled;
   }


### PR DESCRIPTION
updates mediaStreamTrackSetEnabled to work for remote tracks as well as by local tracks.

so setting .enabled on a remote track in js will mute / unmute the track if it is audio.
applies to issues #338 and #179