### PR TITLE
Fix MediaStreamTrack.getSources() result format on iOS

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -322,7 +322,7 @@ RCT_EXPORT_METHOD(mediaStreamTrackGetSources:(RCTPromiseResolveBlock)resolve
                          @"kind": @"audio",
                          }];
   }
-  resolve(@[sources]);
+  resolve(sources);
 }
 
 RCT_EXPORT_METHOD(mediaStreamTrackRelease:(nonnull NSString *)streamID : (nonnull NSString *)trackID)


### PR DESCRIPTION
This fixes an issue with MediaStreamTrack.getSources() not resulting in the expected structure on iOS due to an extra layer of nesting.