### PR TITLE
Added optional argument "constraints" to RTCPeerConnection constructor

### DIFF
--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -106,12 +106,12 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
    */
   _dataChannelIds: Set = new Set();
 
-  constructor(configuration) {
+  constructor(configuration, constraints) {
     super();
     this._peerConnectionId = nextPeerConnectionId++;
     WebRTCModule.peerConnectionInit(
         configuration,
-        DEFAULT_PC_CONSTRAINTS,
+        constraints ? constraints : DEFAULT_PC_CONSTRAINTS,
         this._peerConnectionId);
     this._registerEvents();
     // Allow for legacy callback usage


### PR DESCRIPTION
Currently the user cannot pass the needed "constraints" value to RTCPeerConnection when it is initializing.

This PR allows us to do that.

This PR does not break BC.