### PR TITLE
promisify: pad arguments with undefined if few are passed

### DIFF
--- a/RTCUtil.js
+++ b/RTCUtil.js
@@ -50,6 +50,13 @@ export function promisify(method, callbackFirst) {
       onFailure = function(err) { throw err; };
     }
 
+    // If fewer args were given than the source function
+    // requires, pad out the argument list with undefined.
+    const arity = method.length;
+    while (args.length + 2 < arity) {
+      args.push(undefined);
+    }
+
     // --- always pass resolve/reject as callback
     return new Promise(function(resolve, reject) {
       const newArgs = (callbackFirst ? [resolve, reject, ...args] : [...args, resolve, reject]);


### PR DESCRIPTION
This fixes an issue with getStats().

If you call getStats() with no arguments, promisify will mistakenly call getStats with the successFunction as the `track` and failureFunction as `successFunction`. By padding out the argument list this issue is avoided.