### PR TITLE
Add bundlePolicy to the configuration parser in iOS 

### DIFF
--- a/ios/RCTWebRTC/RCTConvert+WebRTC.h
+++ b/ios/RCTWebRTC/RCTConvert+WebRTC.h
@@ -10,6 +10,7 @@
 + (RTCIceCandidate *)RTCIceCandidate:(id)json;
 + (RTCSessionDescription *)RTCSessionDescription:(id)json;
 + (RTCIceServer *)RTCIceServer:(id)json;
++ (RTCBundlePolicy *)RTCBundlePolicy:(id)json;
 + (RTCDataChannelConfiguration *)RTCDataChannelConfiguration:(id)json;
 + (RTCConfiguration *)RTCConfiguration:(id)json;
 

--- a/ios/RCTWebRTC/RCTConvert+WebRTC.m
+++ b/ios/RCTWebRTC/RCTConvert+WebRTC.m
@@ -2,6 +2,7 @@
 #import <WebRTC/RTCDataChannelConfiguration.h>
 #import <WebRTC/RTCIceServer.h>
 #import <WebRTC/RTCSessionDescription.h>
+#import <WebRTC/RTCConfiguration.h>
 
 @implementation RCTConvert (WebRTC)
 
@@ -85,6 +86,38 @@
   return [[RTCIceServer alloc] initWithURLStrings:urls];
 }
 
++ (RTCBundlePolicy *)RTCBundlePolicy:(id)json
+{
+  if(!json){
+    RCTLogConvertError(json, @"a valid bundle policy value");
+    return nil;
+  }
+
+  if(![json isKindOfClass:[NSString class]]) {
+    RCTLogConvertError(json, @"must be a string");
+    return nil;
+  }
+
+  NSString *maxBundle = @"max-bundle";
+  NSString *maxCompat = @"max-compat";
+  NSString *balanced = @"balanced";
+
+  RTCBundlePolicy value;
+  if([json isEqualToString:maxBundle]) {
+    value = RTCBundlePolicyMaxBundle;
+  } else if([json isEqualToString:maxCompat]) {
+    value = RTCBundlePolicyMaxCompat;
+  } else if([json isEqualToString:balanced]){
+    // default value in RFC
+    value = RTCBundlePolicyBalanced;
+  } else {
+      RCTLogConvertError(json, @"not a valid bundlePolicy value");
+      return nil;
+  }
+  RTCBundlePolicy *pointerValue = &value;
+  return pointerValue;
+}
+
 + (nonnull RTCConfiguration *)RTCConfiguration:(id)json
 {
   RTCConfiguration *config = [[RTCConfiguration alloc] init];
@@ -107,6 +140,13 @@
       }
     }
     config.iceServers = iceServers;
+  }
+
+  if(json[@"bundlePolicy"] != nil && [json[@"bundlePolicy"] isKindOfClass:[NSString class]]) {
+    NSInteger *bundlePolicy = [RCTConvert RTCBundlePolicy:json[@"bundlePolicy"]];
+    if(bundlePolicy != nil){
+      config.bundlePolicy = *bundlePolicy;
+    }
   }
 
   // TODO: Implement the rest of the RTCConfigure options ...


### PR DESCRIPTION
Hi,

This fixes the issue to connect to Pexip MCU by setting the bundlePolicy: "balanced" directly from Javascript.

The RFC https://www.w3.org/TR/webrtc/#rtcbundlepolicy-enum for the enum.
By default in the RTCConfiguration it's supposed to be at "balanced" by default but I guess it would break the behavior for other people so I just left it as it is now by default (I guess the WebRTC Framework take care of it by default).

I'm not an Objective-C dev so tell me if I have done anything wrong. Tested on an Iphone and it works correctly.