### PR TITLE
adding requiresMainQueueSetup method

### DIFF
--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -322,4 +322,9 @@ RCT_CUSTOM_VIEW_PROPERTY(streamURL, NSString *, RTCVideoView) {
   view.videoTrack = videoTrack;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 @end


### PR DESCRIPTION
Since RN 0.49, requiresMainQueueSetup needs to be defined if the module overrides constantsToExport.  will see the warning message when using it

![image](https://user-images.githubusercontent.com/444876/45135524-73de5800-b1d2-11e8-8957-4dd298b23a50.png)

For example: 
https://github.com/facebook/react-native/issues/17504
https://github.com/react-community/lottie-react-native/pull/226/files
https://github.com/react-native-community/react-native-video/pull/871/files

I saw `WebRTCModule` already have `requiresMainQueueSetup` method, so just adding the method in `RTCVideoViewManager.m` too