### PR TITLE
'compile' is obsolete

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compileOnly 'com.facebook.react:react-native:+'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,6 @@ android {
 }
 
 dependencies {
-    compileOnly 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 }


### PR DESCRIPTION
fixed #522 'compile' is obsolete and has been replaced with 'implementation' and 'api'. It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html