### PR TITLE
Use ES6 export

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ import MediaStreamTrack from './MediaStreamTrack';
 import mediaDevices from './MediaDevices';
 import permissions from './Permissions';
 
-module.exports = {
+export {
   RTCPeerConnection,
   RTCIceCandidate,
   RTCSessionDescription,


### PR DESCRIPTION
All files are using ES6 imports and exports except this one that using CommonJS `module.exports`, and in fact is mixing it with ES6 imports. This pull-request fix it having all files using ES6 imports and exports.